### PR TITLE
Fix dev server path

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,8 @@ module.exports = {
   },
   devServer: {
     static: {
-      directory: path.join(__dirname, 'dist')
+      // Serve the project root so index.html is available without a build step
+      directory: __dirname
     },
     port: 8080
   }


### PR DESCRIPTION
## Summary
- serve the project root so `yarn start` can find `index.html`

## Testing
- `yarn test` *(fails: package missing, install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684106391054832d8bcac2de19d3db91