### PR TITLE
Add pulsing win animation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,14 +188,22 @@ document.addEventListener('DOMContentLoaded', () => {
         const sym = reels[cell.c].children[cell.r * 2] as PIXI.Sprite;
         const border = reels[cell.c].children[cell.r * 2 + 1] as PIXI.Sprite;
         if (!hitSprites.includes(sym)) {
-          sym.scale.set(1.2);
-          border.scale.set(1.2);
           hitSprites.push(sym, border);
         }
       });
     });
 
+    const pulseTicker = new PIXI.Ticker();
+    pulseTicker.add(() => {
+      const t = Date.now();
+      const scale = 1 + 0.2 * (0.5 + 0.5 * Math.sin(t / 150));
+      hitSprites.forEach(s => s.scale.set(scale));
+    });
+    pulseTicker.start();
+
     setTimeout(() => {
+      pulseTicker.stop();
+      pulseTicker.destroy();
       hitSprites.forEach(s => s.scale.set(1));
       lineContainer.removeChildren();
       spinning = false;


### PR DESCRIPTION
## Summary
- update win animation so winning symbols smoothly pulse using a PIXI ticker

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ffe85cd4832da81e0e8f518b5712