### PR TITLE
Fix build assets for slot machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "build": "webpack && cp index.html dist/index.html",
+    "build": "webpack && cp index.html dist/index.html && cp -r assets dist",
     "start": "webpack serve --open",
     "test": "webpack"
   },


### PR DESCRIPTION
## Summary
- copy `assets` folder during `npm run build` so slot symbols load in dist builds

## Testing
- `npm test` *(fails: `webpack: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848c1bdfa78832db2f57fa994f13694