### PR TITLE
Fix PIXI import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import PIXI from 'pixi.js';
+import * as PIXI from 'pixi.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const app = new PIXI.Application({


### PR DESCRIPTION
## Summary
- use `import * as PIXI` to ensure `Application` is available

## Testing
- `npm test` *(fails: `webpack: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848ddd6a8bc832d946bcf6bf042dba2