### PR TITLE
Fix win line offset when score area is used

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
   let spinning = false;
   const WIN_TIME = 3000;
   const lineContainer = new PIXI.Container();
+  lineContainer.y = SCORE_AREA_HEIGHT;
   app.stage.addChild(lineContainer);
 
   interface LineInfo {


### PR DESCRIPTION
## Summary
- adjust lineContainer position to match score area

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848e7615b24832d92ef486be4b9be0f