### PR TITLE
Centralize asset paths

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import { AssetPaths } from '../setting';
 
 export abstract class BaseSlotGame {
   protected app!: PIXI.Application;
@@ -88,8 +89,8 @@ export abstract class BaseSlotGame {
       this.reels.push(rc);
       for (let j = 0; j < this.rows; j++) {
         const symIndex = Math.floor(Math.random() * this.currentSymbols.length);
-        const texture = PIXI.Texture.from(`assets/symbols/${this.currentSymbols[symIndex]}.png`);
-        const border = PIXI.Sprite.from('assets/symbols/border.png');
+        const texture = PIXI.Texture.from(`${AssetPaths.bjxb.symbols}${this.currentSymbols[symIndex]}.png`);
+        const border = PIXI.Sprite.from(AssetPaths.bjxb.border);
         const symbol = new PIXI.Sprite(texture);
         symbol.name = this.currentSymbols[symIndex];
         symbol.anchor.set(0.5);
@@ -149,7 +150,7 @@ export abstract class BaseSlotGame {
         const idx = Math.floor(Math.random() * symbolSet.length);
         const sym = this.reels[c].children[r * 2] as any;
         const border = this.reels[c].children[r * 2 + 1] as any;
-        sym.texture = PIXI.Texture.from(`assets/symbols/${symbolSet[idx]}.png`);
+        sym.texture = PIXI.Texture.from(`${AssetPaths.bjxb.symbols}${symbolSet[idx]}.png`);
         sym.name = symbolSet[idx];
         sym.y = r * this.reelHeight + this.reelHeight / 2;
         border.y = sym.y;
@@ -271,14 +272,14 @@ export abstract class BaseSlotGame {
       const sPos = this.cellPos(l.start.r, l.start.c);
       const ePos = this.cellPos(l.end.r, l.end.c);
 
-      const jStart = PIXI.Sprite.from('assets/lines/line_joint.png');
-      const jEnd = PIXI.Sprite.from('assets/lines/line_joint.png');
+      const jStart = PIXI.Sprite.from(AssetPaths.bjxb.lines.joint);
+      const jEnd = PIXI.Sprite.from(AssetPaths.bjxb.lines.joint);
       jStart.anchor.set(0.5);
       jEnd.anchor.set(0.5);
       jStart.position.set(sPos.x, sPos.y);
       jEnd.position.set(ePos.x, ePos.y);
 
-      const body = PIXI.Sprite.from('assets/lines/line_body.png');
+      const body = PIXI.Sprite.from(AssetPaths.bjxb.lines.body);
       body.anchor.set(0.5);
       const dx = ePos.x - sPos.x;
       const dy = ePos.y - sPos.y;
@@ -358,7 +359,7 @@ export abstract class BaseSlotGame {
             sym.y -= this.rows * this.reelHeight;
             border.y = sym.y;
             const symIndex = Math.floor(Math.random() * this.currentSymbols.length);
-            sym.texture = PIXI.Texture.from(`assets/symbols/${this.currentSymbols[symIndex]}.png`);
+            sym.texture = PIXI.Texture.from(`${AssetPaths.bjxb.symbols}${this.currentSymbols[symIndex]}.png`);
             sym.name = this.currentSymbols[symIndex];
           }
         }

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
+import { AssetPaths } from '../../setting';
 
 export class BjxbSlotGame extends BaseSlotGame {
   private hunter!: PIXI.AnimatedSprite;
@@ -14,7 +15,7 @@ export class BjxbSlotGame extends BaseSlotGame {
   private hotSymbols = this.normalSymbols.slice(0, 3);
 
   protected getBackgroundPath(): string {
-    return 'assets/bg/bg.png';
+    return AssetPaths.bjxb.bg;
   }
 
   protected getInitialSymbols(): string[] {
@@ -32,7 +33,7 @@ export class BjxbSlotGame extends BaseSlotGame {
     for (let i = 1; i <= 51; i++) {
       const num = i.toString().padStart(3, '0');
       hunterFrames.push(
-        PIXI.Texture.from(`assets/animation/hunter/hunter_${num}.png`)
+        PIXI.Texture.from(`${AssetPaths.bjxb.animation.hunter}hunter_${num}.png`)
       );
     }
     this.hunter = new PIXI.AnimatedSprite(hunterFrames);

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,0 +1,16 @@
+// Centralized asset path definitions.  Each game should have its paths grouped
+// under its own key so additional games can be added easily.
+export const AssetPaths = {
+  bjxb: {
+    bg: 'assets/bjxb/bg/bg.png',
+    symbols: 'assets/bjxb/symbols/',
+    border: 'assets/bjxb/symbols/border.png',
+    lines: {
+      joint: 'assets/bjxb/lines/line_joint.png',
+      body: 'assets/bjxb/lines/line_body.png'
+    },
+    animation: {
+      hunter: 'assets/bjxb/animation/hunter/'
+    }
+  }
+} as const;


### PR DESCRIPTION
## Summary
- centralize asset paths under `src/setting.ts`
- update `BjxbSlotGame` to use centralized paths
- update `BaseSlotGame` to use centralized paths

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684faf84283c832db17d7da52293112c