### PR TITLE
Implement lobby scene with basic navigation

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -1,0 +1,86 @@
+import * as PIXI from 'pixi.js';
+import { AssetPaths } from './setting';
+
+export class Lobby {
+  private app!: PIXI.Application;
+  private scrollContainer!: PIXI.Container;
+
+  constructor(private onGameSelected: (id: string) => void) {}
+
+  public start(containerId: string = 'game'): void {
+    this.app = new PIXI.Application({
+      width: 1882,
+      height: 1075,
+      backgroundColor: 0x000000
+    });
+    const container = typeof containerId === 'string' ? document.getElementById(containerId)! : containerId;
+    container.appendChild(this.app.view);
+
+    const title = new PIXI.Text('Lobby', {
+      fill: 0xffffff,
+      fontSize: 48,
+      fontWeight: 'bold'
+    });
+    title.anchor.set(0.5);
+    title.position.set(this.app.renderer.width / 2, 60);
+    this.app.stage.addChild(title);
+
+    this.scrollContainer = new PIXI.Container();
+    this.scrollContainer.x = this.app.renderer.width / 2;
+    this.scrollContainer.y = 150;
+    this.app.stage.addChild(this.scrollContainer);
+
+    const entries = [
+      { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb }
+    ];
+
+    const itemSpacing = 220;
+    entries.forEach((entry, idx) => {
+      const yPos = idx * itemSpacing;
+      const icon = PIXI.Sprite.from(entry.icon);
+      icon.anchor.set(0.5);
+      icon.y = yPos;
+      icon.interactive = true;
+      icon.buttonMode = true;
+      icon.on('pointertap', () => this.onGameSelected(entry.id));
+      this.scrollContainer.addChild(icon);
+
+      const label = new PIXI.Text(entry.name, { fill: 0xffffff, fontSize: 36 });
+      label.anchor.set(0.5, 0);
+      label.position.set(0, yPos + icon.height / 2 + 10);
+      label.interactive = true;
+      label.buttonMode = true;
+      label.on('pointertap', () => this.onGameSelected(entry.id));
+      this.scrollContainer.addChild(label);
+    });
+
+    // simple vertical dragging for scrollContainer
+    let dragging = false;
+    let startY = 0;
+    this.scrollContainer.interactive = true;
+    this.scrollContainer.on('pointerdown', e => {
+      dragging = true;
+      startY = e.data.global.y - this.scrollContainer.y;
+    });
+    this.scrollContainer.on('pointermove', e => {
+      if (dragging) {
+        this.scrollContainer.y = e.data.global.y - startY;
+      }
+    });
+    const stopDragging = () => { dragging = false; };
+    this.scrollContainer.on('pointerup', stopDragging);
+    this.scrollContainer.on('pointerupoutside', stopDragging);
+  }
+
+  public destroy(): void {
+    if (this.app) {
+      const parent = this.app.view.parentNode;
+      if (parent) parent.removeChild(this.app.view);
+      this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+    }
+  }
+
+  public get appInstance(): PIXI.Application {
+    return this.app;
+  }
+}

--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -384,5 +384,19 @@ export abstract class BaseSlotGame {
       ticker.start();
     });
   }
+
+  public destroy(): void {
+    if (this.app) {
+      const parent = this.app.view.parentNode;
+      if (parent) {
+        parent.removeChild(this.app.view);
+      }
+      this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+    }
+  }
+
+  public get appInstance(): PIXI.Application {
+    return this.app;
+  }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,47 @@
+import * as PIXI from 'pixi.js';
 import { BjxbSlotGame } from './games/bjxb/BjxbSlotGame';
+import { Lobby } from './Lobby';
+import { AssetPaths } from './setting';
+
+class SceneManager {
+  private current: { destroy(): void; appInstance: PIXI.Application } | null = null;
+
+  public showLobby(): void {
+    this.cleanup();
+    const lobby = new Lobby(id => this.startGame(id));
+    this.current = lobby;
+    lobby.start('game');
+  }
+
+  private startGame(id: string): void {
+    this.cleanup();
+    if (id === 'bjxb') {
+      const game = new BjxbSlotGame();
+      this.current = game;
+      game.start('game');
+      this.addBackButton(game.appInstance);
+    }
+  }
+
+  private addBackButton(app: PIXI.Application): void {
+    const btn = PIXI.Sprite.from(AssetPaths.lobby.backBtn);
+    btn.interactive = true;
+    btn.buttonMode = true;
+    btn.x = 20;
+    btn.y = 20;
+    btn.on('pointertap', () => this.showLobby());
+    app.stage.addChild(btn);
+  }
+
+  private cleanup(): void {
+    if (this.current) {
+      this.current.destroy();
+      this.current = null;
+    }
+  }
+}
 
 document.addEventListener('DOMContentLoaded', () => {
-  const game = new BjxbSlotGame();
-  game.start('game');
+  const manager = new SceneManager();
+  manager.showLobby();
 });
-

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -12,5 +12,9 @@ export const AssetPaths = {
     animation: {
       hunter: 'assets/bjxb/animation/hunter/'
     }
+  },
+  lobby: {
+    backBtn: 'assets/lobby_icon/backBtn.png',
+    bjxb: 'assets/lobby_icon/bjxb.png'
   }
 } as const;


### PR DESCRIPTION
## Summary
- add asset paths for lobby icons
- expose Pixi application from `BaseSlotGame` and allow destruction
- implement `Lobby` scene to list available games
- manage scenes in `index.ts` with back button support

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb3ced128832d9f72fd33a34a7b91