### PR TITLE
Improve lobby scroll view layout

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -4,6 +4,7 @@ import { AssetPaths } from './setting';
 export class Lobby {
   private app!: PIXI.Application;
   private scrollContainer!: PIXI.Container;
+  private viewHeight = 0;
 
   constructor(private onGameSelected: (id: string) => void) {}
 
@@ -21,12 +22,38 @@ export class Lobby {
     bg.height = this.app.renderer.height;
     this.app.stage.addChild(bg);
 
-    this.scrollContainer = new PIXI.Container();
-    this.scrollContainer.x = 0;
-    // position the scroll container a bit lower so icons are not flush with the top
-    this.scrollContainer.y = 250;
+    const margin = 150;
+    const panelWidth = this.app.renderer.width - margin * 2;
+    this.viewHeight = this.app.renderer.height - 400;
 
-    this.app.stage.addChild(this.scrollContainer);
+    const panel = new PIXI.Container();
+    panel.x = margin;
+    panel.y = 200;
+    this.app.stage.addChild(panel);
+
+    const bgPanel = new PIXI.Graphics();
+    bgPanel.beginFill(0x000000, 0.5);
+    bgPanel.drawRoundedRect(0, 0, panelWidth, this.viewHeight, 20);
+    bgPanel.endFill();
+    if (PIXI.filters && PIXI.filters.DropShadowFilter) {
+      bgPanel.filters = [new PIXI.filters.DropShadowFilter({
+        distance: 4,
+        blur: 4,
+        alpha: 0.7,
+        color: 0x000000
+      })];
+    }
+    panel.addChild(bgPanel);
+
+    const mask = new PIXI.Graphics();
+    mask.beginFill(0xffffff);
+    mask.drawRoundedRect(0, 0, panelWidth, this.viewHeight, 20);
+    mask.endFill();
+    panel.addChild(mask);
+
+    this.scrollContainer = new PIXI.Container();
+    this.scrollContainer.mask = mask;
+    panel.addChild(this.scrollContainer);
 
     // variables used for drag and click detection
     let dragging = false;
@@ -37,16 +64,21 @@ export class Lobby {
       { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb }
     ];
 
-    const itemSpacing = 250;
-    // place entries slightly left/right of center
-    const leftX = this.app.renderer.width * 0.4;
-    const rightX = this.app.renderer.width * 0.6;
+    const columns = 2;
+    const iconSize = 170;
+    const colWidth = panelWidth / columns;
+    const rowHeight = iconSize + 60;
+
     entries.forEach((entry, idx) => {
-      const yPos = idx * itemSpacing;
+      const row = Math.floor(idx / columns);
+      const col = idx % columns;
+
       const icon = PIXI.Sprite.from(entry.icon);
       icon.anchor.set(0.5);
-      icon.x = idx % 2 === 0 ? leftX : rightX;
-      icon.y = yPos;
+      icon.width = iconSize;
+      icon.height = iconSize;
+      icon.x = colWidth * col + colWidth / 2;
+      icon.y = row * rowHeight + iconSize / 2 + 20;
       icon.interactive = true;
       icon.buttonMode = true;
       icon.on('pointerup', () => { if (!moved) this.onGameSelected(entry.id); });
@@ -54,21 +86,59 @@ export class Lobby {
 
       const labelStyle = new PIXI.TextStyle({
         fill: 0xffffff,
-        fontSize: 48,
+        fontSize: 36,
         fontWeight: 'bold',
-        align: 'center'
+        align: 'center',
+        stroke: 0x000000,
+        strokeThickness: 4
       });
       const label = new PIXI.Text(entry.name, labelStyle);
       label.anchor.set(0.5, 0);
       label.x = icon.x;
-      label.y = yPos + icon.height / 2 + 10;
+      label.y = icon.y + icon.height / 2 + 10;
       label.interactive = true;
       label.buttonMode = true;
       label.on('pointerup', () => { if (!moved) this.onGameSelected(entry.id); });
       this.scrollContainer.addChild(label);
     });
 
+    const rows = Math.ceil(entries.length / columns);
+    const contentHeight = rows * rowHeight + 20;
+
     // simple vertical dragging for scrollContainer with click detection
+    const minY = Math.min(this.viewHeight - contentHeight, 0);
+
+    const animateTo = (target: number) => {
+      const startPos = this.scrollContainer.y;
+      const delta = target - startPos;
+      const duration = 500;
+      const startTime = Date.now();
+      const easeOutBack = (t: number) => {
+        const c1 = 1.70158;
+        const c3 = c1 + 1;
+        return 1 + c3 * Math.pow(t - 1, 3) + c1 * Math.pow(t - 1, 2);
+      };
+      const ticker = new PIXI.Ticker();
+      ticker.add(() => {
+        const elapsed = Date.now() - startTime;
+        const progress = Math.min(elapsed / duration, 1);
+        this.scrollContainer.y = startPos + delta * easeOutBack(progress);
+        if (progress === 1) {
+          ticker.stop();
+          ticker.destroy();
+        }
+      });
+      ticker.start();
+    };
+
+    const applyBounds = () => {
+      if (this.scrollContainer.y > 0) {
+        animateTo(0);
+      } else if (this.scrollContainer.y < minY) {
+        animateTo(minY);
+      }
+    };
+
     this.scrollContainer.interactive = true;
     this.scrollContainer.on('pointerdown', (e: any) => {
       dragging = true;
@@ -85,7 +155,10 @@ export class Lobby {
       }
     });
     const stopDragging = () => {
-      dragging = false;
+      if (dragging) {
+        dragging = false;
+        applyBounds();
+      }
     };
     this.scrollContainer.on('pointerup', stopDragging);
     this.scrollContainer.on('pointerupoutside', stopDragging);


### PR DESCRIPTION
## Summary
- add panel background with rounded corners and drop shadow
- arrange game icons in two-column grid with names below
- shrink icon sizes and add text styling
- allow scrolling to bounce at edges even when content is short

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc029fa10832d86f2b5d6c3dc39fb