### PR TITLE
Add configurable gameplay settings

### DIFF
--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -1,18 +1,21 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
-import { AssetPaths } from '../../setting';
+import { AssetPaths, DefaultGameSettings, GameRuleSettings } from '../../setting';
 
 export class BjxbSlotGame extends BaseSlotGame {
+  constructor(settings: GameRuleSettings = DefaultGameSettings) {
+    super(settings);
+  }
   private hunter!: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
   private inHotSpin = false;
   private hotSpinsLeft = 0;
-  private nextHotSpinScore = 100;
+  private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
   // Symbols are referenced by number strings (e.g. '001')
   private normalSymbols = Array.from({ length: AssetPaths.bjxb.symbolCount }, (_, i) =>
     (i + 1).toString().padStart(3, '0')
   );
-  private hotSymbols = this.normalSymbols.slice(0, 3);
+  private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);
 
   protected getBackgroundPath(): string {
     return AssetPaths.bjxb.bg;
@@ -91,7 +94,10 @@ export class BjxbSlotGame extends BaseSlotGame {
     this.populateReels(this.currentSymbols);
     this.button.interactive = true;
     this.button.alpha = 1;
-    this.nextHotSpinScore = Math.floor(this.score / 100) * 100 + 100;
+    this.nextHotSpinScore =
+      Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
+        this.gameSettings.hotSpinThresholdMultiple +
+      this.gameSettings.hotSpinThresholdMultiple;
   }
 
   private checkHotSpin() {

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -9,6 +9,23 @@ export interface GameAssetConfig {
   animationFrame: (type: string, index: number) => string;
 }
 
+export interface GameRuleSettings {
+  /** Allowed line directions for scoring */
+  lineDirections: {
+    horizontal: boolean;
+    vertical: boolean;
+    diagonal: boolean;
+  };
+  /** Minimum number of consecutive symbols to score */
+  minMatch: number;
+  /** Score gained per matched symbol */
+  scorePerBlock: number;
+  /** Score multiple required to trigger Hot Spin */
+  hotSpinThresholdMultiple: number;
+  /** Number of symbol types during Hot Spin */
+  hotSpinSymbolTypeCount: number;
+}
+
 function createGameConfig(name: string, symbolCount: number, animations: Record<string, number>): GameAssetConfig {
   return {
     symbolCount,
@@ -38,3 +55,11 @@ export const AssetPaths = {
     bjxb: 'assets/lobby/lobby_icons/bjxb.png'
   }
 } as const;
+
+export const DefaultGameSettings: GameRuleSettings = {
+  lineDirections: { horizontal: true, vertical: true, diagonal: true },
+  minMatch: 3,
+  scorePerBlock: 10,
+  hotSpinThresholdMultiple: 100,
+  hotSpinSymbolTypeCount: 3
+};


### PR DESCRIPTION
## Summary
- allow customizing gameplay rules in `setting.ts`
- modify `BaseSlotGame` to use those settings
- update `BjxbSlotGame` to read from config

## Testing
- `npx -y tsc --noEmit` *(fails: Cannot find namespace 'PIXI')*
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd2932c10832d94543bb466ed3055