### PR TITLE
Add customizable board and block size

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -2,7 +2,12 @@ import * as PIXI from 'pixi.js';
 import { AssetPaths, DefaultGameSettings, GameRuleSettings } from '../setting';
 
 export abstract class BaseSlotGame {
-  constructor(protected gameSettings: GameRuleSettings = DefaultGameSettings) {}
+  constructor(protected gameSettings: GameRuleSettings = DefaultGameSettings) {
+    this.rows = gameSettings.rows;
+    this.cols = gameSettings.cols;
+    this.reelWidth = gameSettings.blockWidth;
+    this.reelHeight = gameSettings.blockHeight;
+  }
 
   protected app!: PIXI.Application;
   protected gameContainer!: PIXI.Container;
@@ -33,10 +38,10 @@ export abstract class BaseSlotGame {
   protected SCORE_AREA_HEIGHT = 100;
   protected APP_WIDTH = 1882;
   protected APP_HEIGHT = 1075;
-  protected reelWidth = 128;
-  protected reelHeight = 128;
-  protected rows = 5;
-  protected cols = 7;
+  protected reelWidth!: number;
+  protected reelHeight!: number;
+  protected rows!: number;
+  protected cols!: number;
   protected REEL_SCALE = 0.9;
 
   // spin configuration

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -24,6 +24,14 @@ export interface GameRuleSettings {
   hotSpinThresholdMultiple: number;
   /** Number of symbol types during Hot Spin */
   hotSpinSymbolTypeCount: number;
+  /** Number of columns (reels) */
+  cols: number;
+  /** Number of rows per reel */
+  rows: number;
+  /** Width of each block (symbol) in pixels */
+  blockWidth: number;
+  /** Height of each block (symbol) in pixels */
+  blockHeight: number;
 }
 
 function createGameConfig(name: string, symbolCount: number, animations: Record<string, number>): GameAssetConfig {
@@ -61,5 +69,9 @@ export const DefaultGameSettings: GameRuleSettings = {
   minMatch: 3,
   scorePerBlock: 10,
   hotSpinThresholdMultiple: 100,
-  hotSpinSymbolTypeCount: 3
+  hotSpinSymbolTypeCount: 3,
+  cols: 7,
+  rows: 5,
+  blockWidth: 128,
+  blockHeight: 128
 };


### PR DESCRIPTION
## Summary
- allow tuning board dimensions and symbol size through `GameRuleSettings`
- use new settings to configure `BaseSlotGame`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685220149ec0832dbf10b2c6a783c036