### PR TITLE
Add new FFP slot game

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -73,7 +73,8 @@ export class Lobby {
     let startY = 0;
 
     const entries = [
-      { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb }
+      { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb },
+      { id: 'ffp', name: '水果盤', icon: AssetPaths.lobby.ffp }
     ];
 
     const columns = ICON_COLUMNS;

--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -1,8 +1,11 @@
 import * as PIXI from 'pixi.js';
-import { AssetPaths, DefaultGameSettings, GameRuleSettings } from '../setting';
+import { AssetPaths, DefaultGameSettings, GameRuleSettings, GameAssetConfig } from '../setting';
 
 export abstract class BaseSlotGame {
-  constructor(protected gameSettings: GameRuleSettings = DefaultGameSettings) {
+  constructor(
+    protected gameSettings: GameRuleSettings = DefaultGameSettings,
+    protected assets: GameAssetConfig = AssetPaths.bjxb
+  ) {
     this.rows = gameSettings.rows;
     this.cols = gameSettings.cols;
     this.reelWidth = gameSettings.blockWidth;
@@ -114,9 +117,9 @@ export abstract class BaseSlotGame {
         const symIndex = Math.floor(Math.random() * this.currentSymbols.length);
         const symbolName = this.currentSymbols[symIndex];
         const texture = PIXI.Texture.from(
-          AssetPaths.bjxb.symbol(Number(symbolName))
+          this.assets.symbol(Number(symbolName))
         );
-        const border = PIXI.Sprite.from(AssetPaths.bjxb.border);
+        const border = PIXI.Sprite.from(this.assets.border);
         const symbol = new PIXI.Sprite(texture);
         symbol.name = symbolName;
         symbol.anchor.set(0.5);
@@ -177,7 +180,7 @@ export abstract class BaseSlotGame {
         const sym = this.reels[c].children[r * 2] as any;
         const border = this.reels[c].children[r * 2 + 1] as any;
         sym.texture = PIXI.Texture.from(
-          AssetPaths.bjxb.symbol(Number(symbolSet[idx]))
+          this.assets.symbol(Number(symbolSet[idx]))
         );
         sym.name = symbolSet[idx];
         sym.y = r * this.reelHeight + this.reelHeight / 2;
@@ -306,14 +309,14 @@ export abstract class BaseSlotGame {
       const sPos = this.cellPos(l.start.r, l.start.c);
       const ePos = this.cellPos(l.end.r, l.end.c);
 
-      const jStart = PIXI.Sprite.from(AssetPaths.bjxb.lines.joint);
-      const jEnd = PIXI.Sprite.from(AssetPaths.bjxb.lines.joint);
+      const jStart = PIXI.Sprite.from(this.assets.lines.joint);
+      const jEnd = PIXI.Sprite.from(this.assets.lines.joint);
       jStart.anchor.set(0.5);
       jEnd.anchor.set(0.5);
       jStart.position.set(sPos.x, sPos.y);
       jEnd.position.set(ePos.x, ePos.y);
 
-      const body = PIXI.Sprite.from(AssetPaths.bjxb.lines.body);
+      const body = PIXI.Sprite.from(this.assets.lines.body);
       body.anchor.set(0.5);
       const dx = ePos.x - sPos.x;
       const dy = ePos.y - sPos.y;
@@ -399,7 +402,7 @@ export abstract class BaseSlotGame {
             const symIndex = Math.floor(Math.random() * this.currentSymbols.length);
             const symbolName = this.currentSymbols[symIndex];
             sym.texture = PIXI.Texture.from(
-              AssetPaths.bjxb.symbol(Number(symbolName))
+              this.assets.symbol(Number(symbolName))
             );
             sym.name = symbolName;
           }

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -1,10 +1,10 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
-import { AssetPaths, DefaultGameSettings, GameRuleSettings } from '../../setting';
+import { AssetPaths, GameRuleSettings, FfpGameSettings } from '../../setting';
 
-export class BjxbSlotGame extends BaseSlotGame {
-  constructor(settings: GameRuleSettings = DefaultGameSettings) {
-    super(settings, AssetPaths.bjxb);
+export class FfpSlotGame extends BaseSlotGame {
+  constructor(settings: GameRuleSettings = FfpGameSettings) {
+    super(settings, AssetPaths.ffp);
   }
   private hunter!: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
@@ -12,13 +12,13 @@ export class BjxbSlotGame extends BaseSlotGame {
   private hotSpinsLeft = 0;
   private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
   // Symbols are referenced by number strings (e.g. '001')
-  private normalSymbols = Array.from({ length: AssetPaths.bjxb.symbolCount }, (_, i) =>
+  private normalSymbols = Array.from({ length: AssetPaths.ffp.symbolCount }, (_, i) =>
     (i + 1).toString().padStart(3, '0')
   );
   private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);
 
   protected getBackgroundPath(): string {
-    return AssetPaths.bjxb.bg;
+    return AssetPaths.ffp.bg;
   }
 
   protected getInitialSymbols(): string[] {
@@ -33,9 +33,9 @@ export class BjxbSlotGame extends BaseSlotGame {
     const HUNTER_Y_OFFSET = this.SCORE_AREA_HEIGHT + 190;
 
     const hunterFrames: PIXI.Texture[] = [];
-    for (let i = 1; i <= AssetPaths.bjxb.animations.hunter; i++) {
+    for (let i = 1; i <= AssetPaths.ffp.animations.hunter; i++) {
       hunterFrames.push(
-        PIXI.Texture.from(AssetPaths.bjxb.animationFrame('hunter', i))
+        PIXI.Texture.from(AssetPaths.ffp.animationFrame('hunter', i))
       );
     }
     this.hunter = new PIXI.AnimatedSprite(hunterFrames);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { BjxbSlotGame } from './games/bjxb/BjxbSlotGame';
+import { FfpSlotGame } from './games/ffp/FfpSlotGame';
 import { Lobby } from './Lobby';
 import { AssetPaths } from './setting';
 
@@ -17,6 +18,11 @@ class SceneManager {
     this.cleanup();
     if (id === 'bjxb') {
       const game = new BjxbSlotGame();
+      this.current = game;
+      game.start('game');
+      this.addBackButton(game.appInstance);
+    } else if (id === 'ffp') {
+      const game = new FfpSlotGame();
       this.current = game;
       game.start('game');
       this.addBackButton(game.appInstance);

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -57,10 +57,12 @@ function createGameConfig(name: string, symbolCount: number, animations: Record<
 
 export const AssetPaths = {
   bjxb: createGameConfig('bjxb', 10, { hunter: 51 }),
+  ffp: createGameConfig('ffp', 6, { hunter: 51 }),
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
     backBtn: 'assets/lobby/backBtn.png',
-    bjxb: 'assets/lobby/lobby_icons/bjxb.png'
+    bjxb: 'assets/lobby/lobby_icons/bjxb.png',
+    ffp: 'assets/lobby/lobby_icons/ffp.png'
   }
 } as const;
 
@@ -74,4 +76,12 @@ export const DefaultGameSettings: GameRuleSettings = {
   rows: 5,
   blockWidth: 128,
   blockHeight: 128
+};
+
+export const FfpGameSettings: GameRuleSettings = {
+  ...DefaultGameSettings,
+  cols: 5,
+  rows: 5,
+  blockWidth: 128,
+  blockHeight: 90
 };


### PR DESCRIPTION
## Summary
- parametrize BaseSlotGame to accept assets
- wire up FFP game settings and assets
- implement FfpSlotGame
- register new game in lobby and scene manager

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685227eb8e54832d87a1191149d2305a