### PR TITLE
Make animations optional

### DIFF
--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -6,7 +6,7 @@ export class BjxbSlotGame extends BaseSlotGame {
   constructor(settings: GameRuleSettings = DefaultGameSettings) {
     super(settings, AssetPaths.bjxb);
   }
-  private hunter!: PIXI.AnimatedSprite;
+  private hunter?: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
   private inHotSpin = false;
   private hotSpinsLeft = 0;
@@ -32,22 +32,25 @@ export class BjxbSlotGame extends BaseSlotGame {
     const HUNTER_X_OFFSET = 250;
     const HUNTER_Y_OFFSET = this.SCORE_AREA_HEIGHT + 190;
 
-    const hunterFrames: PIXI.Texture[] = [];
-    for (let i = 1; i <= AssetPaths.bjxb.animations.hunter; i++) {
-      hunterFrames.push(
-        PIXI.Texture.from(AssetPaths.bjxb.animationFrame('hunter', i))
-      );
+    if (this.assets.animations?.hunter) {
+      const hunterFrames: PIXI.Texture[] = [];
+      for (let i = 1; i <= this.assets.animations.hunter; i++) {
+        hunterFrames.push(
+          PIXI.Texture.from(this.assets.animationFrame('hunter', i))
+        );
+      }
+      this.hunter = new PIXI.AnimatedSprite(hunterFrames);
+      this.hunter.animationSpeed = 0.1667;
+      this.hunter.loop = true;
+      this.hunter.anchor.set(0.5);
+      this.hunter.scale.set(HUNTER_SCALE);
+      this.hunter.x = this.gameContainer.x + GAME_WIDTH + HUNTER_X_OFFSET;
+      this.hunter.y =
+        this.gameContainer.y + this.SCORE_AREA_HEIGHT + HUNTER_Y_OFFSET +
+        (this.rows * this.reelHeight) / 2;
+      this.hunter.gotoAndStop(0);
+      this.app.stage.addChild(this.hunter);
     }
-    this.hunter = new PIXI.AnimatedSprite(hunterFrames);
-    this.hunter.animationSpeed = 0.1667;
-    this.hunter.loop = true;
-    this.hunter.anchor.set(0.5);
-    this.hunter.scale.set(HUNTER_SCALE);
-    this.hunter.x = this.gameContainer.x + GAME_WIDTH + HUNTER_X_OFFSET;
-    this.hunter.y = this.gameContainer.y + this.SCORE_AREA_HEIGHT + HUNTER_Y_OFFSET +
-      (this.rows * this.reelHeight) / 2;
-    this.hunter.gotoAndStop(0);
-    this.app.stage.addChild(this.hunter);
 
     this.hotSpinText = new PIXI.Text('', {
       fill: 0xff0000,
@@ -67,7 +70,9 @@ export class BjxbSlotGame extends BaseSlotGame {
   }
 
   private startHotSpin() {
-    this.hunter.play();
+    if (this.hunter) {
+      this.hunter.play();
+    }
     this.inHotSpin = true;
     this.hotSpinsLeft = 3;
     this.hotSpinText.visible = true;
@@ -86,7 +91,9 @@ export class BjxbSlotGame extends BaseSlotGame {
   }
 
   private endHotSpin() {
-    this.hunter.gotoAndStop(0);
+    if (this.hunter) {
+      this.hunter.gotoAndStop(0);
+    }
     this.inHotSpin = false;
     this.hotSpinText.visible = false;
     this.hotSpinText.text = '';

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -6,7 +6,7 @@ export class FfpSlotGame extends BaseSlotGame {
   constructor(settings: GameRuleSettings = FfpGameSettings) {
     super(settings, AssetPaths.ffp);
   }
-  private hunter!: PIXI.AnimatedSprite;
+  private hunter?: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
   private inHotSpin = false;
   private hotSpinsLeft = 0;
@@ -32,22 +32,25 @@ export class FfpSlotGame extends BaseSlotGame {
     const HUNTER_X_OFFSET = 250;
     const HUNTER_Y_OFFSET = this.SCORE_AREA_HEIGHT + 190;
 
-    const hunterFrames: PIXI.Texture[] = [];
-    for (let i = 1; i <= AssetPaths.ffp.animations.hunter; i++) {
-      hunterFrames.push(
-        PIXI.Texture.from(AssetPaths.ffp.animationFrame('hunter', i))
-      );
+    if (this.assets.animations?.hunter) {
+      const hunterFrames: PIXI.Texture[] = [];
+      for (let i = 1; i <= this.assets.animations.hunter; i++) {
+        hunterFrames.push(
+          PIXI.Texture.from(this.assets.animationFrame('hunter', i))
+        );
+      }
+      this.hunter = new PIXI.AnimatedSprite(hunterFrames);
+      this.hunter.animationSpeed = 0.1667;
+      this.hunter.loop = true;
+      this.hunter.anchor.set(0.5);
+      this.hunter.scale.set(HUNTER_SCALE);
+      this.hunter.x = this.gameContainer.x + GAME_WIDTH + HUNTER_X_OFFSET;
+      this.hunter.y =
+        this.gameContainer.y + this.SCORE_AREA_HEIGHT + HUNTER_Y_OFFSET +
+        (this.rows * this.reelHeight) / 2;
+      this.hunter.gotoAndStop(0);
+      this.app.stage.addChild(this.hunter);
     }
-    this.hunter = new PIXI.AnimatedSprite(hunterFrames);
-    this.hunter.animationSpeed = 0.1667;
-    this.hunter.loop = true;
-    this.hunter.anchor.set(0.5);
-    this.hunter.scale.set(HUNTER_SCALE);
-    this.hunter.x = this.gameContainer.x + GAME_WIDTH + HUNTER_X_OFFSET;
-    this.hunter.y = this.gameContainer.y + this.SCORE_AREA_HEIGHT + HUNTER_Y_OFFSET +
-      (this.rows * this.reelHeight) / 2;
-    this.hunter.gotoAndStop(0);
-    this.app.stage.addChild(this.hunter);
 
     this.hotSpinText = new PIXI.Text('', {
       fill: 0xff0000,
@@ -67,7 +70,9 @@ export class FfpSlotGame extends BaseSlotGame {
   }
 
   private startHotSpin() {
-    this.hunter.play();
+    if (this.hunter) {
+      this.hunter.play();
+    }
     this.inHotSpin = true;
     this.hotSpinsLeft = 3;
     this.hotSpinText.visible = true;
@@ -86,7 +91,9 @@ export class FfpSlotGame extends BaseSlotGame {
   }
 
   private endHotSpin() {
-    this.hunter.gotoAndStop(0);
+    if (this.hunter) {
+      this.hunter.gotoAndStop(0);
+    }
     this.inHotSpin = false;
     this.hotSpinText.visible = false;
     this.hotSpinText.text = '';

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,7 +1,7 @@
 export interface GameAssetConfig {
   symbolCount: number;
   // animation type to frame count
-  animations: Record<string, number>;
+  animations?: Record<string, number>;
   bg: string;
   border: string;
   lines: { joint: string; body: string };
@@ -34,7 +34,7 @@ export interface GameRuleSettings {
   blockHeight: number;
 }
 
-function createGameConfig(name: string, symbolCount: number, animations: Record<string, number>): GameAssetConfig {
+function createGameConfig(name: string, symbolCount: number, animations?: Record<string, number>): GameAssetConfig {
   return {
     symbolCount,
     animations,
@@ -57,7 +57,7 @@ function createGameConfig(name: string, symbolCount: number, animations: Record<
 
 export const AssetPaths = {
   bjxb: createGameConfig('bjxb', 10, { hunter: 51 }),
-  ffp: createGameConfig('ffp', 6, { hunter: 51 }),
+  ffp: createGameConfig('ffp', 6),
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
     backBtn: 'assets/lobby/backBtn.png',


### PR DESCRIPTION
## Summary
- allow `animations` to be optional in `GameAssetConfig`
- skip loading hunter animation if no animation is defined
- remove animation config from ffp game

## Testing
- `npx tsc --noEmit` *(fails: Cannot find namespace 'PIXI')*
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68522c85ca64832db55b8fc7034a55af