### PR TITLE
Add BaseMapShip feature

### DIFF
--- a/src/base/BaseMapShip.ts
+++ b/src/base/BaseMapShip.ts
@@ -1,0 +1,62 @@
+import * as PIXI from 'pixi.js';
+
+export class BaseMapShip {
+  private container: PIXI.Container;
+  private flag!: PIXI.Sprite;
+  private winner!: PIXI.Sprite;
+  private battles: PIXI.Sprite[] = [];
+  private routes: { x: number; y: number }[] = [];
+  private current = 0;
+
+  constructor(private app: PIXI.Application, private gameCode: string) {
+    this.container = new PIXI.Container();
+  }
+
+  public async init(): Promise<void> {
+    const base = `assets/${this.gameCode}/map/${this.gameCode}_map_`;
+    const routeResp = await fetch(`${base}routes.json`);
+    const data = (await routeResp.json()) as { routes: { x: number; y: number }[] };
+    this.routes = data.routes.map(p => ({ x: Number(p.x), y: Number(p.y) }));
+
+    const reel = PIXI.Sprite.from(`${base}reel.png`);
+    this.container.addChild(reel);
+
+    const battleTex = PIXI.Texture.from(`${base}battle.png`);
+    for (let i = 1; i < this.routes.length - 1; i++) {
+      const b = new PIXI.Sprite(battleTex);
+      b.anchor.set(0.5);
+      b.x = this.routes[i].x;
+      b.y = this.routes[i].y;
+      this.battles.push(b);
+      this.container.addChild(b);
+    }
+
+    this.winner = PIXI.Sprite.from(`${base}winner.png`);
+    this.winner.anchor.set(0.5);
+    this.winner.x = this.routes[this.routes.length - 1].x;
+    this.winner.y = this.routes[this.routes.length - 1].y;
+    this.container.addChild(this.winner);
+
+    this.flag = PIXI.Sprite.from(`${base}flag.png`);
+    this.flag.anchor.set(0.5);
+    this.flag.x = this.routes[0].x;
+    this.flag.y = this.routes[0].y;
+    this.container.addChild(this.flag);
+
+    this.app.stage.addChild(this.container);
+  }
+
+  public moveToNext(): void {
+    if (this.current + 1 >= this.routes.length) return;
+    this.current++;
+    this.flag.x = this.routes[this.current].x;
+    this.flag.y = this.routes[this.current].y;
+  }
+
+  public destroy(): void {
+    if (this.container.parent) {
+      this.container.parent.removeChild(this.container);
+    }
+    this.container.destroy({ children: true, texture: true, baseTexture: true });
+  }
+}

--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { AssetPaths, DefaultGameSettings, GameRuleSettings, GameAssetConfig } from '../setting';
+import { BaseMapShip } from './BaseMapShip';
 
 export abstract class BaseSlotGame {
   constructor(
@@ -22,6 +23,7 @@ export abstract class BaseSlotGame {
   protected score = 0;
   protected scoreText!: PIXI.Text;
   protected button!: PIXI.Container;
+  protected mapShip?: BaseMapShip;
 
   private activeTickers: PIXI.Ticker[] = [];
   private activeTimeouts: number[] = [];
@@ -82,6 +84,13 @@ export abstract class BaseSlotGame {
     background.width = this.APP_WIDTH;
     background.height = this.APP_HEIGHT;
     this.app.stage.addChild(background);
+
+    if (this.gameSettings.mapShip) {
+      const m = /assets\/(.*?)\//.exec(this.assets.bg);
+      const code = m ? m[1] : '';
+      this.mapShip = new BaseMapShip(this.app, code);
+      this.mapShip.init();
+    }
 
     this.gameContainer = new PIXI.Container();
     this.gameContainer.x = (this.APP_WIDTH - GAME_WIDTH) / 2;
@@ -452,6 +461,10 @@ export abstract class BaseSlotGame {
     this.activeTimeouts = [];
     this.activeTickers.forEach(t => t.destroy());
     this.activeTickers = [];
+    if (this.mapShip) {
+      this.mapShip.destroy();
+      this.mapShip = undefined;
+    }
     if (this.app) {
       const parent = this.app.view.parentNode;
       if (parent) {

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -33,6 +33,8 @@ export interface GameRuleSettings {
   blockWidth: number;
   /** Height of each block (symbol) in pixels */
   blockHeight: number;
+  /** Enable map ship feature */
+  mapShip: boolean;
 }
 
 function createGameConfig(
@@ -86,7 +88,8 @@ export const DefaultGameSettings: GameRuleSettings = {
   cols: 7,
   rows: 5,
   blockWidth: 128,
-  blockHeight: 128
+  blockHeight: 128,
+  mapShip: false
 };
 
 export const FfpGameSettings: GameRuleSettings = {
@@ -94,5 +97,6 @@ export const FfpGameSettings: GameRuleSettings = {
   cols: 5,
   rows: 5,
   blockWidth: 128,
-  blockHeight: 90
+  blockHeight: 90,
+  mapShip: true
 };


### PR DESCRIPTION
## Summary
- introduce `BaseMapShip` class for handling map ship feature
- allow slot games to load map ship resources when `mapShip` is enabled in settings
- extend `GameRuleSettings` with `mapShip` flag
- enable map ship in FFP game settings

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a499fc794832dbf10780a70938e03