### PR TITLE
Add Alpszm slot game

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -74,7 +74,8 @@ export class Lobby {
 
     const entries = [
       { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb },
-      { id: 'ffp', name: '水果盤', icon: AssetPaths.lobby.ffp }
+      { id: 'ffp', name: '水果盤', icon: AssetPaths.lobby.ffp },
+      { id: 'alpszm', name: '奧林帕斯', icon: AssetPaths.lobby.alpszm }
     ];
 
     const columns = ICON_COLUMNS;

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -1,0 +1,130 @@
+import * as PIXI from 'pixi.js';
+import { BaseSlotGame } from '../../base/BaseSlotGame';
+import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
+
+export class AlpszmSlotGame extends BaseSlotGame {
+  constructor(settings: GameRuleSettings = AlpszmGameSettings) {
+    super(settings, AssetPaths.alpszm);
+  }
+  private hunter?: PIXI.AnimatedSprite;
+  private hotSpinText!: PIXI.Text;
+  private inHotSpin = false;
+  private hotSpinsLeft = 0;
+  private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
+  // Symbols are referenced by number strings (e.g. '001')
+  private normalSymbols = Array.from({ length: AssetPaths.alpszm.symbolCount }, (_, i) =>
+    (i + 1).toString().padStart(3, '0')
+  );
+  private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);
+
+  protected getBackgroundPath(): string {
+    return AssetPaths.alpszm.bg;
+  }
+
+  protected getInitialSymbols(): string[] {
+    return this.normalSymbols;
+  }
+
+  public start(containerId: string = 'game'): void {
+    super.start(containerId);
+    const GAME_WIDTH = this.cols * this.reelWidth;
+    const HUNTER_SCALE = 1;
+    const HUNTER_X_OFFSET = 250;
+    const HUNTER_Y_OFFSET = this.SCORE_AREA_HEIGHT + 190;
+
+    if (this.assets.animations?.hunter) {
+      const hunterFrames: PIXI.Texture[] = [];
+      for (let i = 1; i <= this.assets.animations.hunter; i++) {
+        hunterFrames.push(
+          PIXI.Texture.from(this.assets.animationFrame('hunter', i))
+        );
+      }
+      this.hunter = new PIXI.AnimatedSprite(hunterFrames);
+      this.hunter.animationSpeed = 0.1667;
+      this.hunter.loop = true;
+      this.hunter.anchor.set(0.5);
+      this.hunter.scale.set(HUNTER_SCALE);
+      this.hunter.x = this.gameContainer.x + GAME_WIDTH + HUNTER_X_OFFSET;
+      this.hunter.y =
+        this.gameContainer.y + this.SCORE_AREA_HEIGHT + HUNTER_Y_OFFSET +
+        (this.rows * this.reelHeight) / 2;
+      this.hunter.gotoAndStop(0);
+      this.app.stage.addChild(this.hunter);
+    }
+
+    this.hotSpinText = new PIXI.Text('', {
+      fill: 0xff0000,
+      fontSize: 48,
+      fontWeight: 'bold',
+      stroke: 0x333333,
+      strokeThickness: 6
+    });
+    this.hotSpinText.x = 20;
+    this.hotSpinText.y = 20;
+    this.hotSpinText.visible = false;
+    this.gameContainer.addChild(this.hotSpinText);
+  }
+
+  protected onSpinEnd(): void {
+    this.checkHotSpin();
+  }
+
+  private startHotSpin() {
+    if (this.hunter) {
+      this.hunter.play();
+    }
+    this.inHotSpin = true;
+    this.hotSpinsLeft = 3;
+    this.hotSpinText.visible = true;
+    this.hotSpinText.text = `Hot Spin!! ${this.hotSpinsLeft}`;
+    this.button.interactive = false;
+    this.button.alpha = 0.5;
+    this.currentSymbols = this.hotSymbols;
+    this.populateReels(this.currentSymbols);
+    this.spin(() => {
+      this.hotSpinsLeft--;
+      if (this.hotSpinsLeft > 0) {
+        this.hotSpinText.text = `Hot Spin!! ${this.hotSpinsLeft}`;
+      }
+      this.checkHotSpin();
+    });
+  }
+
+  private endHotSpin() {
+    if (this.hunter) {
+      this.hunter.gotoAndStop(0);
+    }
+    this.inHotSpin = false;
+    this.hotSpinText.visible = false;
+    this.hotSpinText.text = '';
+    this.currentSymbols = this.normalSymbols;
+    this.populateReels(this.currentSymbols);
+    this.button.interactive = true;
+    this.button.alpha = 1;
+    this.nextHotSpinScore =
+      Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
+        this.gameSettings.hotSpinThresholdMultiple +
+      this.gameSettings.hotSpinThresholdMultiple;
+  }
+
+  private checkHotSpin() {
+    if (this.inHotSpin) {
+      if (this.hotSpinsLeft > 0) {
+        this.spin(() => {
+          this.hotSpinsLeft--;
+          if (this.hotSpinsLeft > 0) {
+            this.hotSpinText.text = `Hot Spin!! ${this.hotSpinsLeft}`;
+          }
+          this.checkHotSpin();
+        });
+      } else {
+        this.endHotSpin();
+      }
+    } else {
+      if (this.score >= this.nextHotSpinScore) {
+        this.startHotSpin();
+      }
+    }
+  }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { BjxbSlotGame } from './games/bjxb/BjxbSlotGame';
 import { FfpSlotGame } from './games/ffp/FfpSlotGame';
+import { AlpszmSlotGame } from './games/alpszm/AlpszmSlotGame';
 import { Lobby } from './Lobby';
 import { AssetPaths } from './setting';
 
@@ -23,6 +24,11 @@ class SceneManager {
       this.addBackButton(game.appInstance);
     } else if (id === 'ffp') {
       const game = new FfpSlotGame();
+      this.current = game;
+      game.start('game');
+      this.addBackButton(game.appInstance);
+    } else if (id === 'alpszm') {
+      const game = new AlpszmSlotGame();
       this.current = game;
       game.start('game');
       this.addBackButton(game.appInstance);

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -71,11 +71,13 @@ function createGameConfig(
 export const AssetPaths = {
   bjxb: createGameConfig('bjxb', 10, { hunter: 51 }, true),
   ffp: createGameConfig('ffp', 6, undefined, false),
+  alpszm: createGameConfig('alpszm', 13, undefined, false),
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
     backBtn: 'assets/lobby/backBtn.png',
     bjxb: 'assets/lobby/lobby_icons/bjxb.png',
-    ffp: 'assets/lobby/lobby_icons/ffp.png'
+    ffp: 'assets/lobby/lobby_icons/ffp.png',
+    alpszm: 'assets/lobby/lobby_icons/alpszm.png'
   }
 } as const;
 
@@ -98,5 +100,14 @@ export const FfpGameSettings: GameRuleSettings = {
   rows: 5,
   blockWidth: 128,
   blockHeight: 90,
+  mapShip: true
+};
+
+export const AlpszmGameSettings: GameRuleSettings = {
+  ...DefaultGameSettings,
+  cols: 5,
+  rows: 3,
+  blockWidth: 120,
+  blockHeight: 140,
   mapShip: true
 };


### PR DESCRIPTION
## Summary
- add AlpszmSlotGame using existing slot game logic
- register alpszm assets and settings
- add alpszm entry in lobby and in scene manager

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5e719ea4832d9ff53fb849a4fa44