### PR TITLE
Fix lobby scroll view

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -2,16 +2,16 @@ import * as PIXI from 'pixi.js';
 import { AssetPaths } from './setting';
 
 // layout parameters for easy adjustments
-const SCROLL_MARGIN = 400;          // horizontal margin for the scroll view
-const SCROLL_Y = 0;               // vertical position of the scroll view
-const VIEW_HEIGHT_OFFSET = 0;     // height = renderer.height - VIEW_HEIGHT_OFFSET
+const SCROLL_MARGIN = 150;          // horizontal margin for the scroll view
+const SCROLL_Y = 200;               // vertical position of the scroll view
+const VIEW_HEIGHT_OFFSET = 400;     // height = renderer.height - VIEW_HEIGHT_OFFSET
 
 const ICON_COLUMNS = 2;             // how many icons per row
-const ICON_SIZE = 300;              // width/height of each icon
-const FIRST_ICON_Y_OFFSET = 50;     // offset for the first icon's y position
+const ICON_SIZE = 170;              // width/height of each icon
+const FIRST_ICON_Y_OFFSET = 20;     // offset for the first icon's y position
 const ICON_ROW_EXTRA = 60;          // extra space between icon rows
-const FIRST_ICON_X_RATIO = 0.6;     // starting x position as a ratio of column width
-const ICON_X_DIFF_MULTIPLIER = 0.8;   // spacing multiplier between icons horizontally
+const FIRST_ICON_X_RATIO = 0.5;     // starting x position as a ratio of column width
+const ICON_X_DIFF_MULTIPLIER = 1;   // spacing multiplier between icons horizontally
 
 export class Lobby {
   private app!: PIXI.Application;
@@ -100,16 +100,6 @@ export class Lobby {
       icon.on('pointerup', () => { if (!moved) this.onGameSelected(entry.id); });
       this.scrollContainer.addChild(icon);
 
-      // 建立一個帶圓角的圖形遮罩
-      const mask = new PIXI.Graphics();
-      mask.beginFill(0xffffff);
-      mask.drawRoundedRect(0, 0, icon.width, icon.height, 20); // 20 是圓角半徑
-      mask.endFill();
-      // 位置與 icon 對齊
-      mask.x = icon.x - icon.width / 2;
-      mask.y = icon.y - icon.height / 2;
-      this.scrollContainer.addChild(mask);
-      icon.mask = mask;
 
       const labelStyle = new PIXI.TextStyle({
         fill: 0xffffff,


### PR DESCRIPTION
## Summary
- restore lobby scroll view layout constants
- remove icon mask elements to match earlier working version

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a5fc39260832da2c58e8d8152c831