### PR TITLE
Fix background scaling for small assets

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -238,10 +238,10 @@ export abstract class BaseSlotGame {
       const bottom = PIXI.Sprite.from(this.assets.bgBottom);
 
       const layout = () => {
-        const scale = this.APP_WIDTH / top.texture.width;
+        const scale = Math.min(this.APP_WIDTH / top.texture.width, 1);
         [top, mid, bottom].forEach(s => {
           s.scale.set(scale);
-          s.x = 0;
+          s.x = (this.APP_WIDTH - top.texture.width * scale) / 2;
         });
         top.y = 0;
         mid.y = top.height;


### PR DESCRIPTION
## Summary
- stop upscaling background pieces when they are narrower than the app width

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file - running an install might help)*

------
https://chatgpt.com/codex/tasks/task_e_685a6bc4e288832daf4a52538e8721f1