### PR TITLE
Add reel spacing and scale settings

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -13,6 +13,9 @@ export abstract class BaseSlotGame {
     this.reelHeight = gameSettings.blockHeight;
     this.hasBorder = !!assets.border;
     this.childPerCell = this.hasBorder ? 2 : 1;
+    this.colSpacing = gameSettings.colSpacing;
+    this.rowSpacing = gameSettings.rowSpacing;
+    this.blockScale = gameSettings.blockScale;
   }
 
   protected app!: PIXI.Application;
@@ -50,6 +53,9 @@ export abstract class BaseSlotGame {
   protected rows!: number;
   protected cols!: number;
   protected REEL_SCALE = 0.9;
+  protected colSpacing = 0;
+  protected rowSpacing = 0;
+  protected blockScale = 1;
 
   // spin configuration
   protected BASE_SPIN = 1000;
@@ -68,8 +74,12 @@ export abstract class BaseSlotGame {
   protected abstract getInitialSymbols(): string[];
 
   public start(containerId: string = 'game'): void {
-    const GAME_WIDTH = this.cols * this.reelWidth;
-    const GAME_HEIGHT = this.rows * this.reelHeight + 100 + this.SCORE_AREA_HEIGHT;
+    const REEL_LAYOUT_WIDTH =
+      this.cols * this.reelWidth + (this.cols - 1) * this.colSpacing;
+    const REEL_LAYOUT_HEIGHT =
+      this.rows * this.reelHeight + (this.rows - 1) * this.rowSpacing;
+    const GAME_WIDTH = REEL_LAYOUT_WIDTH;
+    const GAME_HEIGHT = REEL_LAYOUT_HEIGHT + 100 + this.SCORE_AREA_HEIGHT;
     this.currentSymbols = this.getInitialSymbols();
 
     this.app = new PIXI.Application({
@@ -105,28 +115,28 @@ export abstract class BaseSlotGame {
       this.reelContainer = new PIXI.Container();
       let scale = this.REEL_SCALE;
       if (this.gameSettings.reelWidth) {
-        scale = this.gameSettings.reelWidth / (this.cols * this.reelWidth);
+        scale =
+          this.gameSettings.reelWidth /
+          (REEL_LAYOUT_WIDTH);
       }
       if (this.gameSettings.reelHeight) {
         const hScale =
-          this.gameSettings.reelHeight / (this.rows * this.reelHeight);
+          this.gameSettings.reelHeight /
+          (REEL_LAYOUT_HEIGHT);
         scale = Math.min(scale, hScale);
       }
       this.REEL_SCALE = scale;
       this.reelContainer.scale.set(this.REEL_SCALE);
 
-      let defaultX =
-        (GAME_WIDTH - this.cols * this.reelWidth * this.REEL_SCALE) / 2;
+      const scaledWidth = REEL_LAYOUT_WIDTH * this.REEL_SCALE;
+      const scaledHeight = REEL_LAYOUT_HEIGHT * this.REEL_SCALE;
+      let defaultX = (GAME_WIDTH - scaledWidth) / 2;
       let defaultY = this.SCORE_AREA_HEIGHT;
       if (!this.gameSettings.singleBackground && midBg) {
         const midX = midBg.x - this.gameContainer.x;
         const midY = midBg.y - this.gameContainer.y;
-        defaultX =
-          midX +
-          (midBg.width - this.cols * this.reelWidth * this.REEL_SCALE) / 2;
-        defaultY =
-          midY +
-          (midBg.height - this.rows * this.reelHeight * this.REEL_SCALE) / 2;
+        defaultX = midX + (midBg.width - scaledWidth) / 2;
+        defaultY = midY + (midBg.height - scaledHeight) / 2;
       }
       this.reelContainer.x =
         this.gameSettings.reelX !== undefined
@@ -147,25 +157,20 @@ export abstract class BaseSlotGame {
         strokeThickness: 6
       });
       this.scoreText.anchor.set(0.5, 0);
-      this.scoreText.x = (this.cols * this.reelWidth) / 2;
+      this.scoreText.x = REEL_LAYOUT_WIDTH / 2;
       this.scoreText.y = 20;
       this.gameContainer.addChild(this.scoreText);
 
       const reelMask = new PIXI.Graphics();
       reelMask.beginFill(0xffffff);
-      reelMask.drawRect(
-        0,
-        0,
-        this.cols * this.reelWidth,
-        this.rows * this.reelHeight
-      );
+      reelMask.drawRect(0, 0, REEL_LAYOUT_WIDTH, REEL_LAYOUT_HEIGHT);
       reelMask.endFill();
       this.reelContainer.addChild(reelMask);
       this.reelContainer.mask = reelMask;
 
       for (let i = 0; i < this.cols; i++) {
         const rc = new PIXI.Container();
-        rc.x = i * this.reelWidth;
+        rc.x = i * (this.reelWidth + this.colSpacing);
         this.reelContainer.addChild(rc);
         this.reels.push(rc);
         for (let j = 0; j < this.rows; j++) {
@@ -180,13 +185,16 @@ export abstract class BaseSlotGame {
           symbol.name = symbolName;
           symbol.anchor.set(0.5);
           symbol.x = this.reelWidth / 2;
-          symbol.y = j * this.reelHeight + this.reelHeight / 2;
+          symbol.y =
+            j * (this.reelHeight + this.rowSpacing) + this.reelHeight / 2;
+          symbol.scale.set(this.blockScale);
           rc.addChild(symbol);
           if (this.hasBorder && this.assets.border) {
             const border = PIXI.Sprite.from(this.assets.border);
             border.anchor.set(0.5);
             border.x = this.reelWidth / 2;
             border.y = symbol.y;
+            border.scale.set(this.blockScale);
             rc.addChild(border);
           }
         }
@@ -211,8 +219,8 @@ export abstract class BaseSlotGame {
       this.button.addChild(buttonText);
       this.button.interactive = true;
       this.button.buttonMode = true;
-      this.button.x = (this.cols * this.reelWidth - btnBgWidth) / 2;
-      this.button.y = this.rows * this.reelHeight + 20 + this.SCORE_AREA_HEIGHT;
+      this.button.x = (REEL_LAYOUT_WIDTH - btnBgWidth) / 2;
+      this.button.y = REEL_LAYOUT_HEIGHT + 20 + this.SCORE_AREA_HEIGHT;
       this.gameContainer.addChild(this.button);
 
       this.lineContainer = new PIXI.Container();
@@ -314,8 +322,12 @@ export abstract class BaseSlotGame {
           this.assets.symbol(Number(symbolSet[idx]))
         );
         sym.name = symbolSet[idx];
-        sym.y = r * this.reelHeight + this.reelHeight / 2;
-        if (border) border.y = sym.y;
+        sym.y = r * (this.reelHeight + this.rowSpacing) + this.reelHeight / 2;
+        sym.scale.set(this.blockScale);
+        if (border) {
+          border.y = sym.y;
+          border.scale.set(this.blockScale);
+        }
       }
     }
   }
@@ -410,7 +422,10 @@ export abstract class BaseSlotGame {
   }
 
   protected cellPos(r: number, c: number) {
-    return { x: c * this.reelWidth + this.reelWidth / 2, y: r * this.reelHeight + this.reelHeight / 2 };
+    return {
+      x: c * (this.reelWidth + this.colSpacing) + this.reelWidth / 2,
+      y: r * (this.reelHeight + this.rowSpacing) + this.reelHeight / 2
+    };
   }
 
   protected animateScore() {
@@ -484,7 +499,7 @@ export abstract class BaseSlotGame {
     this.registerTicker(pulseTicker);
     pulseTicker.add(() => {
       const t = Date.now();
-      const scale = 1 + 0.2 * (0.5 + 0.5 * Math.sin(t / 150));
+      const scale = this.blockScale * (1 + 0.2 * (0.5 + 0.5 * Math.sin(t / 150)));
       hitSprites.forEach(s => s.scale.set(scale));
     });
     pulseTicker.start();
@@ -493,7 +508,7 @@ export abstract class BaseSlotGame {
       pulseTicker.stop();
       pulseTicker.destroy();
       this.unregisterTicker(pulseTicker);
-      hitSprites.forEach(s => s.scale.set(1));
+      hitSprites.forEach(s => s.scale.set(this.blockScale));
       this.lineContainer.removeChildren();
       this.onSpinEnd();
       onDone();
@@ -504,8 +519,10 @@ export abstract class BaseSlotGame {
   protected alignReel(reel: PIXI.Container) {
     reel.children.forEach((child: any, i: number) => {
       const row = Math.floor(i / this.childPerCell);
-      child.y = row * this.reelHeight + this.reelHeight / 2;
+      child.y =
+        row * (this.reelHeight + this.rowSpacing) + this.reelHeight / 2;
       child.x = this.reelWidth / 2;
+      child.scale.set(this.blockScale);
     });
   }
 
@@ -532,8 +549,10 @@ export abstract class BaseSlotGame {
           const border = this.hasBorder ? (reel.children[i + 1] as any) : null;
           sym.y += this.SPIN_SPEED * ticker.deltaTime;
           if (border) border.y = sym.y;
-          if (sym.y >= this.rows * this.reelHeight + this.reelHeight / 2) {
-            sym.y -= this.rows * this.reelHeight;
+          const totalHeight =
+            this.rows * (this.reelHeight + this.rowSpacing) - this.rowSpacing;
+          if (sym.y >= totalHeight + this.reelHeight / 2) {
+            sym.y -= totalHeight;
             if (border) border.y = sym.y;
             const symIndex = Math.floor(
               Math.random() * this.currentSymbols.length

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -37,6 +37,12 @@ export interface GameRuleSettings {
   blockWidth: number;
   /** Height of each block (symbol) in pixels */
   blockHeight: number;
+  /** Horizontal spacing between columns in pixels */
+  colSpacing: number;
+  /** Vertical spacing between rows in pixels */
+  rowSpacing: number;
+  /** Scale factor for each block */
+  blockScale: number;
   /** Enable map ship feature */
   mapShip: boolean;
   /** Use a single background image instead of top/mid/bottom pieces */
@@ -108,6 +114,9 @@ export const DefaultGameSettings: GameRuleSettings = {
   rows: 5,
   blockWidth: 128,
   blockHeight: 128,
+  colSpacing: 0,
+  rowSpacing: 0,
+  blockScale: 1,
   mapShip: false,
   singleBackground: false
 };


### PR DESCRIPTION
## Summary
- make column/row spacing and block scale configurable
- apply spacing and scale to slot layout and animations

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b92eed59c832da125b9ed391ed5bc