### PR TITLE
Integrate map ship with spins

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -27,6 +27,7 @@ export abstract class BaseSlotGame {
   protected scoreText!: PIXI.Text;
   protected button!: PIXI.Container;
   protected mapShip?: BaseMapShip;
+  protected mapShipEndTriggered = false;
 
   private activeTickers: PIXI.Ticker[] = [];
   private activeTimeouts: number[] = [];
@@ -108,6 +109,8 @@ export abstract class BaseSlotGame {
               midBg.x + (midBg.width - this.mapShip!.width) / 2;
             this.mapShip!.setPosition(midBg.x, midBg.y - this.mapShip!.height);
           }
+          this.mapShip!.setMoveTime(1000);
+          this.mapShip!.setOnReachedEnd(() => this.onMapShipEnd());
         });
       }
 
@@ -310,6 +313,10 @@ export abstract class BaseSlotGame {
     // subclasses can override
   }
 
+  protected onMapShipEnd(): void {
+    this.mapShipEndTriggered = true;
+  }
+
   protected populateReels(symbolSet: string[]): void {
     for (let c = 0; c < this.cols; c++) {
       for (let r = 0; r < this.rows; r++) {
@@ -449,6 +456,9 @@ export abstract class BaseSlotGame {
   }
 
   protected showWin(lines: any[], onDone: () => void) {
+    if (this.mapShip) {
+      this.mapShip.moveBy(lines.length);
+    }
     const hitSprites: any[] = [];
     const uniqueCells = new Set<string>();
     lines.forEach(l => {

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -66,10 +66,16 @@ export class AlpszmSlotGame extends BaseSlotGame {
   }
 
   protected onSpinEnd(): void {
-    this.checkHotSpin();
+    if (this.mapShipEndTriggered) {
+      this.mapShipEndTriggered = false;
+      this.startHotSpin();
+    } else {
+      this.checkHotSpin();
+    }
   }
 
-  private startHotSpin() {
+
+  protected startHotSpin() {
     if (this.hunter) {
       this.hunter.play();
     }
@@ -105,6 +111,9 @@ export class AlpszmSlotGame extends BaseSlotGame {
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +
       this.gameSettings.hotSpinThresholdMultiple;
+    if (this.mapShip) {
+      this.mapShip.reset();
+    }
   }
 
   private checkHotSpin() {

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -66,10 +66,16 @@ export class BjxbSlotGame extends BaseSlotGame {
   }
 
   protected onSpinEnd(): void {
-    this.checkHotSpin();
+    if (this.mapShipEndTriggered) {
+      this.mapShipEndTriggered = false;
+      this.startHotSpin();
+    } else {
+      this.checkHotSpin();
+    }
   }
 
-  private startHotSpin() {
+
+  protected startHotSpin() {
     if (this.hunter) {
       this.hunter.play();
     }
@@ -105,6 +111,9 @@ export class BjxbSlotGame extends BaseSlotGame {
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +
       this.gameSettings.hotSpinThresholdMultiple;
+    if (this.mapShip) {
+      this.mapShip.reset();
+    }
   }
 
   private checkHotSpin() {

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -66,10 +66,16 @@ export class FfpSlotGame extends BaseSlotGame {
   }
 
   protected onSpinEnd(): void {
-    this.checkHotSpin();
+    if (this.mapShipEndTriggered) {
+      this.mapShipEndTriggered = false;
+      this.startHotSpin();
+    } else {
+      this.checkHotSpin();
+    }
   }
 
-  private startHotSpin() {
+
+  protected startHotSpin() {
     if (this.hunter) {
       this.hunter.play();
     }
@@ -105,6 +111,9 @@ export class FfpSlotGame extends BaseSlotGame {
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +
       this.gameSettings.hotSpinThresholdMultiple;
+    if (this.mapShip) {
+      this.mapShip.reset();
+    }
   }
 
   private checkHotSpin() {


### PR DESCRIPTION
## Summary
- animate map ship movement per winning line
- trigger HotSpin once the ship reaches the final node
- reset ship position after HotSpin
- expose hook for subclasses and update all games

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b97f68598832db65cc22f4196ddb9