### PR TITLE
Adjust HotSpin trigger logic

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -130,7 +130,7 @@ export class AlpszmSlotGame extends BaseSlotGame {
         this.endHotSpin();
       }
     } else {
-      if (this.score >= this.nextHotSpinScore) {
+      if (!this.gameSettings.mapShip && this.score >= this.nextHotSpinScore) {
         this.startHotSpin();
       }
     }

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -130,7 +130,7 @@ export class BjxbSlotGame extends BaseSlotGame {
         this.endHotSpin();
       }
     } else {
-      if (this.score >= this.nextHotSpinScore) {
+      if (!this.gameSettings.mapShip && this.score >= this.nextHotSpinScore) {
         this.startHotSpin();
       }
     }

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -130,7 +130,7 @@ export class FfpSlotGame extends BaseSlotGame {
         this.endHotSpin();
       }
     } else {
-      if (this.score >= this.nextHotSpinScore) {
+      if (!this.gameSettings.mapShip && this.score >= this.nextHotSpinScore) {
         this.startHotSpin();
       }
     }


### PR DESCRIPTION
## Summary
- hot spin should only trigger from score threshold when mapShip is disabled

## Testing
- `yarn test` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_685b9c13b47c832d8add9f1f5547db0e