### PR TITLE
Add animated spin button

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -1,6 +1,7 @@
 import * as PIXI from 'pixi.js';
 import { AssetPaths, DefaultGameSettings, GameRuleSettings, GameAssetConfig } from '../setting';
 import { BaseMapShip } from './BaseMapShip';
+import { SpinButton } from './SpinButton';
 
 export abstract class BaseSlotGame {
   constructor(
@@ -203,40 +204,56 @@ export abstract class BaseSlotGame {
         }
       }
 
-      this.button = new PIXI.Container();
-      const btnBgWidth = 160;
-      const btnBgHeight = 60;
-      const buttonBg = new PIXI.Graphics();
-      buttonBg.beginFill(0xffe066);
-      buttonBg.lineStyle(2, 0xffffff);
-      buttonBg.drawRoundedRect(0, 0, btnBgWidth, btnBgHeight, 10);
-      buttonBg.endFill();
-      const buttonText = new PIXI.Text('SPIN', {
-        fill: 0x000000,
-        fontSize: 36,
-        fontWeight: 'bold'
-      });
-      buttonText.anchor.set(0.5);
-      buttonText.position.set(btnBgWidth / 2, btnBgHeight / 2);
-      this.button.addChild(buttonBg);
-      this.button.addChild(buttonText);
-      this.button.interactive = true;
-      this.button.buttonMode = true;
-      this.button.x = (REEL_LAYOUT_WIDTH - btnBgWidth) / 2;
-      this.button.y = REEL_LAYOUT_HEIGHT + 20 + this.SCORE_AREA_HEIGHT;
-      this.gameContainer.addChild(this.button);
+      if (this.gameSettings.spinButton) {
+        const btn = new SpinButton(gameCode, () => {
+          this.spin(() => {
+            if (btn) btn.reset();
+            this.onSpinEnd();
+          });
+        });
+        const layoutBtn = () => {
+          btn.x = (REEL_LAYOUT_WIDTH - btn.width) / 2;
+          btn.y = REEL_LAYOUT_HEIGHT + 20 + this.SCORE_AREA_HEIGHT;
+        };
+        btn.on('loaded', layoutBtn);
+        if (btn.width > 0) layoutBtn();
+        this.button = btn;
+        this.gameContainer.addChild(btn);
+      } else {
+        this.button = new PIXI.Container();
+        const btnBgWidth = 160;
+        const btnBgHeight = 60;
+        const buttonBg = new PIXI.Graphics();
+        buttonBg.beginFill(0xffe066);
+        buttonBg.lineStyle(2, 0xffffff);
+        buttonBg.drawRoundedRect(0, 0, btnBgWidth, btnBgHeight, 10);
+        buttonBg.endFill();
+        const buttonText = new PIXI.Text('SPIN', {
+          fill: 0x000000,
+          fontSize: 36,
+          fontWeight: 'bold'
+        });
+        buttonText.anchor.set(0.5);
+        buttonText.position.set(btnBgWidth / 2, btnBgHeight / 2);
+        this.button.addChild(buttonBg);
+        this.button.addChild(buttonText);
+        this.button.interactive = true;
+        this.button.buttonMode = true;
+        this.button.x = (REEL_LAYOUT_WIDTH - btnBgWidth) / 2;
+        this.button.y = REEL_LAYOUT_HEIGHT + 20 + this.SCORE_AREA_HEIGHT;
+        this.gameContainer.addChild(this.button);
+        this.button.on('pointerdown', () => {
+          this.spin(() => {
+            this.onSpinEnd();
+          });
+        });
+      }
 
       this.lineContainer = new PIXI.Container();
       this.lineContainer.x = this.reelContainer.x;
       this.lineContainer.y = this.reelContainer.y;
       this.lineContainer.scale.set(this.REEL_SCALE);
       this.gameContainer.addChild(this.lineContainer);
-
-      this.button.on('pointerdown', () => {
-        this.spin(() => {
-          this.onSpinEnd();
-        });
-      });
     };
 
     if (this.gameSettings.singleBackground) {

--- a/src/base/SpinButton.ts
+++ b/src/base/SpinButton.ts
@@ -1,0 +1,82 @@
+import * as PIXI from 'pixi.js';
+
+export class SpinButton extends PIXI.Container {
+  private base: PIXI.Sprite;
+  private spinIcon: PIXI.Sprite;
+  private stopIcon: PIXI.Sprite;
+  private idleAnim: PIXI.AnimatedSprite;
+  private overlayAnim: PIXI.AnimatedSprite;
+  private disabled = false;
+
+  constructor(gameCode: string, private onPressed: () => void) {
+    super();
+    const prefix = `assets/${gameCode}/spinButton/`;
+    this.base = PIXI.Sprite.from(`${prefix}Btn_Spin_Get.png`);
+    this.spinIcon = PIXI.Sprite.from(`${prefix}Btn_Spin_Spin.png`);
+    this.stopIcon = PIXI.Sprite.from(`${prefix}Btn_Spin_Stop.png`);
+    [this.base, this.spinIcon, this.stopIcon].forEach(s => {
+      s.anchor.set(0.5);
+    });
+    this.stopIcon.visible = false;
+    this.addChild(this.base);
+    this.addChild(this.spinIcon);
+    this.addChild(this.stopIcon);
+
+    const idleFrames: PIXI.Texture[] = [];
+    for (let i = 0; i <= 23; i++) {
+      idleFrames.push(
+        PIXI.Texture.from(`${prefix}Btn_Spin_btn_spin_Up_Spine_Up_${i}.png`)
+      );
+    }
+    this.idleAnim = new PIXI.AnimatedSprite(idleFrames);
+    this.idleAnim.anchor.set(0.5);
+    this.idleAnim.animationSpeed = 0.5;
+    this.idleAnim.loop = true;
+    this.idleAnim.play();
+    this.addChild(this.idleAnim);
+
+    const overlayFrames: PIXI.Texture[] = [];
+    for (let i = 0; i <= 12; i++) {
+      overlayFrames.push(
+        PIXI.Texture.from(`${prefix}Btn_Spin_btn_spin_overlay_spin_overlay_${i}.png`)
+      );
+    }
+    this.overlayAnim = new PIXI.AnimatedSprite(overlayFrames);
+    this.overlayAnim.anchor.set(0.5);
+    this.overlayAnim.loop = false;
+    this.overlayAnim.visible = false;
+    this.overlayAnim.animationSpeed = 0.5;
+    this.overlayAnim.onComplete = () => {
+      this.overlayAnim.visible = false;
+    };
+    this.addChild(this.overlayAnim);
+
+    this.interactive = true;
+    this.buttonMode = true;
+    this.on('pointerdown', () => this.handleClick());
+
+    if (this.base.texture.baseTexture.valid) {
+      this.emit('loaded');
+    } else {
+      this.base.texture.baseTexture.once('loaded', () => this.emit('loaded'));
+    }
+  }
+
+  private handleClick() {
+    if (this.disabled) return;
+    this.disabled = true;
+    this.spinIcon.visible = false;
+    this.stopIcon.visible = true;
+    this.overlayAnim.visible = true;
+    this.overlayAnim.gotoAndPlay(0);
+    if (this.onPressed) this.onPressed();
+  }
+
+  public reset(): void {
+    this.disabled = false;
+    this.spinIcon.visible = true;
+    this.stopIcon.visible = false;
+    this.overlayAnim.stop();
+    this.overlayAnim.visible = false;
+  }
+}

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -107,6 +107,9 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.populateReels(this.currentSymbols);
     this.button.interactive = true;
     this.button.alpha = 1;
+    if (this.button.reset) {
+      (this.button as any).reset();
+    }
     this.nextHotSpinScore =
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -107,6 +107,9 @@ export class BjxbSlotGame extends BaseSlotGame {
     this.populateReels(this.currentSymbols);
     this.button.interactive = true;
     this.button.alpha = 1;
+    if ((this.button as any).reset) {
+      (this.button as any).reset();
+    }
     this.nextHotSpinScore =
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -107,6 +107,9 @@ export class FfpSlotGame extends BaseSlotGame {
     this.populateReels(this.currentSymbols);
     this.button.interactive = true;
     this.button.alpha = 1;
+    if ((this.button as any).reset) {
+      (this.button as any).reset();
+    }
     this.nextHotSpinScore =
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *
         this.gameSettings.hotSpinThresholdMultiple +

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -47,6 +47,8 @@ export interface GameRuleSettings {
   mapShip: boolean;
   /** Use a single background image instead of top/mid/bottom pieces */
   singleBackground: boolean;
+  /** Use animated image spin button */
+  spinButton: boolean;
   /** Custom reel container X position */
   reelX?: number;
   /** Custom reel container Y position */
@@ -118,7 +120,8 @@ export const DefaultGameSettings: GameRuleSettings = {
   rowSpacing: 0,
   blockScale: 1,
   mapShip: false,
-  singleBackground: false
+  singleBackground: false,
+  spinButton: false
 };
 
 export const BjxbGameSettings: GameRuleSettings = {
@@ -148,4 +151,5 @@ export const AlpszmGameSettings: GameRuleSettings = {
   rowSpacing: 32,
   blockScale: 1.2,
   reelY:190,
+  spinButton: true
 };


### PR DESCRIPTION
## Summary
- implement `SpinButton` class to show animated spin controls
- allow games to enable the new spin button through `GameRuleSettings`
- wire `BaseSlotGame` to create `SpinButton` when configured
- enable animated spin button for the alpszm game
- keep old behaviour for bjxb and ffp

## Testing
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bac386b18832d958255b1087987a8