### PR TITLE
Fix spin button reset check

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -107,8 +107,9 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.populateReels(this.currentSymbols);
     this.button.interactive = true;
     this.button.alpha = 1;
-    if (this.button.reset) {
-      (this.button as any).reset();
+    const btn = this.button as any;
+    if (typeof btn.reset === 'function') {
+      btn.reset();
     }
     this.nextHotSpinScore =
       Math.floor(this.score / this.gameSettings.hotSpinThresholdMultiple) *


### PR DESCRIPTION
## Summary
- ensure button reset works even when button type is generic

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bae41e590832db451ebf5b22a6092