### PR TITLE
Fix spin timeout callback arguments

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -688,9 +688,11 @@ export abstract class BaseSlotGame {
           }
         });
         ticker.start();
+        }
+        );
       }, idx * this.START_DELAY);
       this.registerTimeout(timeoutId);
-    })});
+    });
   }
 
   public destroy(): void {


### PR DESCRIPTION
## Summary
- close the animateReelOffset callback before calling `setTimeout`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbd5d7820832db2c8d7820edff6d2