### PR TITLE
Implement PixiDragonBones and use in Alpszm game

### DIFF
--- a/src/base/PixiDragonBones.ts
+++ b/src/base/PixiDragonBones.ts
@@ -1,0 +1,81 @@
+import * as PIXI from 'pixi.js';
+
+// Minimal typings for dragonBones global provided by pixi5-dragonbones
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+declare const dragonBones: any;
+
+/**
+ * PixiDragonBones
+ * A lightweight DragonBones wrapper for Pixi.js 5.x
+ */
+export class PixiDragonBones extends PIXI.Container {
+  private armatureDisplay?: any;
+  private loadPromise: Promise<void>;
+  constructor(
+    private gameCode: string,
+    private resName: string,
+    private armatureName: string
+  ) {
+    super();
+    this.loadPromise = this.loadResources();
+  }
+
+  private loadResources(): Promise<void> {
+    return new Promise(resolve => {
+      const basePath = `assets/${this.gameCode}/dragonBones/`;
+      const skePath = `${basePath}${this.resName}_ske.json`;
+      const texJsonPath = `${basePath}${this.resName}_tex.json`;
+      const texPngPath = `${basePath}${this.resName}_tex.png`;
+
+      const loader = new PIXI.Loader();
+      loader
+        .add('ske', skePath)
+        .add('texJson', texJsonPath)
+        .add('texPng', texPngPath)
+        .load((l, r) => {
+          try {
+            const factory = dragonBones.PixiFactory.factory;
+            factory.parseDragonBonesData(r.ske.data);
+            factory.parseTextureAtlasData(r.texJson.data, r.texPng.texture);
+            this.armatureDisplay = factory.buildArmatureDisplay(this.armatureName);
+            if (this.armatureDisplay) {
+              this.addChild(this.armatureDisplay);
+            } else {
+              // eslint-disable-next-line no-console
+              console.warn(`Armature ${this.armatureName} not found in ${this.resName}`);
+            }
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.warn('Failed to load dragonbones resources', e);
+          }
+          resolve();
+        });
+    });
+  }
+
+  public async play(animName?: string, loop = true): Promise<void> {
+    await this.loadPromise;
+    if (!this.armatureDisplay || !this.armatureDisplay.animation) return;
+    const name = animName || this.armatureDisplay.animation.lastAnimationName;
+    const playTimes = loop ? 0 : 1;
+    this.armatureDisplay.animation.play(name, playTimes);
+  }
+
+  public async stop(): Promise<void> {
+    await this.loadPromise;
+    if (this.armatureDisplay && this.armatureDisplay.animation) {
+      this.armatureDisplay.animation.stop();
+    }
+  }
+
+  public release(): void {
+    if (this.armatureDisplay) {
+      if (this.armatureDisplay.animation) {
+        this.armatureDisplay.animation.stop();
+      }
+      this.armatureDisplay.destroy({ children: true, texture: false });
+      this.armatureDisplay = undefined;
+    }
+    this.removeChildren();
+  }
+}

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -1,5 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
+import { PixiDragonBones } from '../../base/PixiDragonBones';
 import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
 
 export class AlpszmSlotGame extends BaseSlotGame {
@@ -63,6 +64,17 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.hotSpinText.y = 20;
     this.hotSpinText.visible = false;
     this.gameContainer.addChild(this.hotSpinText);
+
+    const alpszm_effect_auto = new PixiDragonBones(
+      'alpszm',
+      'alpszm_a',
+      'Anim_Btn_Auto'
+    );
+    alpszm_effect_auto.name = 'alpszm_effect_auto';
+    alpszm_effect_auto.x = 544;
+    alpszm_effect_auto.y = 1121;
+    alpszm_effect_auto.play();
+    this.gameContainer.addChild(alpszm_effect_auto);
   }
 
   protected onSpinEnd(): void {


### PR DESCRIPTION
## Summary
- add `PixiDragonBones` class for showing DragonBones animations in Pixi.js
- integrate the new class in `AlpszmSlotGame`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d0f363630832d8388829d699407c0