### PR TITLE
Add ResourceManager and preload dragonBones before launching games

### DIFF
--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -1,0 +1,37 @@
+import * as PIXI from 'pixi.js';
+
+// webpack require context for all dragonBones assets
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const dragonBonesContext = (require as any).context('../../assets', true, /dragonBones\/.*\.(json|png)$/);
+
+export class ResourceManager {
+  private static loadedGames: Record<string, boolean> = {};
+
+  public static preloadDragonBones(gameCode: string): Promise<void> {
+    if (this.loadedGames[gameCode]) {
+      return Promise.resolve();
+    }
+
+    const resources = dragonBonesContext
+      .keys()
+      .filter((key: string) => key.includes(`/${gameCode}/dragonBones/`));
+
+    if (resources.length === 0) {
+      this.loadedGames[gameCode] = true;
+      return Promise.resolve();
+    }
+
+    const loader = new PIXI.Loader();
+    resources.forEach((key: string) => {
+      const url = dragonBonesContext(key);
+      loader.add(url, url);
+    });
+
+    return new Promise(resolve => {
+      loader.load(() => {
+        this.loadedGames[gameCode] = true;
+        resolve();
+      });
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,19 +4,22 @@ import { FfpSlotGame } from './games/ffp/FfpSlotGame';
 import { AlpszmSlotGame } from './games/alpszm/AlpszmSlotGame';
 import { Lobby } from './Lobby';
 import { AssetPaths } from './setting';
+import { ResourceManager } from './base/ResourceManager';
 
 class SceneManager {
   private current: { destroy(): void; appInstance: PIXI.Application } | null = null;
 
   public showLobby(): void {
     this.cleanup();
-    const lobby = new Lobby(id => this.startGame(id));
+    const lobby = new Lobby(id => { void this.startGame(id); });
     this.current = lobby;
     lobby.start('game');
   }
 
-  private startGame(id: string): void {
+  private async startGame(id: string): Promise<void> {
     this.cleanup();
+    await ResourceManager.preloadDragonBones(id);
+
     if (id === 'bjxb') {
       const game = new BjxbSlotGame();
       this.current = game;


### PR DESCRIPTION
## Summary
- add `ResourceManager` for caching DragonBones assets
- load DragonBones resources before each game starts

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d19e9c028832d9e0d6ee9208ca4c4