### PR TITLE
Fix JSON parsing in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       },
       {
         test: /\.json$/,
-        type: 'javascript/auto' // ✅ 確保 .json 不被當成 ES 模組解析
+        type: 'json' // ✅ 使用內建 JSON 解析，避免解析錯誤
       }
     ]
   },


### PR DESCRIPTION
## Summary
- use webpack's built-in JSON module type instead of `javascript/auto`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d1d894e68832da8783f58c342a546