### PR TITLE
Fix duplicate resource loader names

### DIFF
--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -24,7 +24,7 @@ export class ResourceManager {
     const loader = new PIXI.Loader();
     resources.forEach((key: string) => {
       const url = dragonBonesContext(key);
-      loader.add(url, url);
+      loader.add(key, url);
     });
 
     return new Promise(resolve => {


### PR DESCRIPTION
## Summary
- ensure each resource added to the Pixi loader uses its file path as the unique name

## Testing
- `npm test` *(fails: `webpack` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3ce3a468832db921225a2f9b409a