### PR TITLE
Fix dragonbones resource paths

### DIFF
--- a/src/base/PixiDragonBones.ts
+++ b/src/base/PixiDragonBones.ts
@@ -1,4 +1,5 @@
 import * as PIXI from 'pixi.js';
+import { ResourceManager } from './ResourceManager';
 
 /**
  * PixiDragonBones
@@ -21,16 +22,14 @@ export class PixiDragonBones extends PIXI.Container {
 
   private loadResources(): Promise<void> {
     return new Promise(resolve => {
-      const basePath = `assets/${this.gameCode}/dragonBones/`;
-      const skePath = `${basePath}${this.resName}_ske.json`;
-      const texJsonPath = `${basePath}${this.resName}_tex.json`;
-      const texPngPath = `${basePath}${this.resName}_tex.png`;
+      const { ske, texJson, texPng } =
+        ResourceManager.getDragonBonesPaths(this.gameCode, this.resName);
 
       const loader = new PIXI.Loader();
       loader
-        .add('ske', skePath)
-        .add('texJson', texJsonPath)
-        .add('texPng', texPngPath)
+        .add('ske', ske)
+        .add('texJson', texJson)
+        .add('texPng', texPng)
         .load((l, r) => {
           try {
             if (

--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -34,4 +34,19 @@ export class ResourceManager {
       });
     });
   }
+
+  public static getDragonBonesPaths(
+    gameCode: string,
+    resName: string
+  ): { ske: string; texJson: string; texPng: string } {
+    const base = `./${gameCode}/dragonBones/`;
+    const skeKey = `${base}${resName}_ske.json`;
+    const texJsonKey = `${base}${resName}_tex.json`;
+    const texPngKey = `${base}${resName}_tex.png`;
+    return {
+      ske: dragonBonesContext(skeKey),
+      texJson: dragonBonesContext(texJsonKey),
+      texPng: dragonBonesContext(texPngKey)
+    } as const;
+  }
 }


### PR DESCRIPTION
## Summary
- use ResourceManager to lookup dragonBones asset URLs
- expose `getDragonBonesPaths` helper

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e3f1b534c832dbe624b3c16344654