### PR TITLE
Fix dragonbones JSON loading

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
       },
       {
         test: /\.json$/,
-        type: 'json' // ✅ 使用內建 JSON 解析，避免解析錯誤
+        type: 'asset/resource' // Export JSON files as separate assets for runtime loading
       }
     ]
   },


### PR DESCRIPTION
## Summary
- make webpack treat json as separate assets so PIXI loader can fetch them

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e40a90538832d81029d34ea49937e