### PR TITLE
Fix global PIXI for pixi5-dragonbones

### DIFF
--- a/src/base/PixiDragonBones.ts
+++ b/src/base/PixiDragonBones.ts
@@ -1,9 +1,9 @@
 import * as PIXI from 'pixi.js';
 import { ResourceManager } from './ResourceManager';
+// Some versions of pixi5-dragonbones expect PIXI on window. Assign before require.
+(window as any).PIXI = PIXI;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dragonBones = require('pixi5-dragonbones');
-// Some versions of pixi5-dragonbones expect PIXI on window
-(window as any).PIXI = PIXI;
 
 /**
  * PixiDragonBones

--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -1,4 +1,6 @@
 import * as PIXI from 'pixi.js';
+// Expose PIXI globally for pixi5-dragonbones which expects a global PIXI.
+(window as any).PIXI = PIXI;
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const dragonBones = require('pixi5-dragonbones');
 


### PR DESCRIPTION
## Summary
- fix loading order for pixi5-dragonbones by assigning PIXI to window before requiring
- expose global PIXI in `ResourceManager` as well

## Testing
- `npm test` *(fails: `webpack: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e49fbc218832db32bf0b8a869ba9b