### PR TITLE
Implement PixiDragonBonesButton

### DIFF
--- a/src/base/PixiDragonBonesButton.ts
+++ b/src/base/PixiDragonBonesButton.ts
@@ -1,0 +1,54 @@
+import * as PIXI from 'pixi.js';
+import { PixiDragonBones } from './PixiDragonBones';
+
+export class PixiDragonBonesButton extends PIXI.Container {
+  private base: PIXI.Sprite;
+  private effect: PixiDragonBones;
+
+  constructor(
+    gameCode: string,
+    baseTextureName: string,
+    resName: string,
+    armatureName: string
+  ) {
+    super();
+
+    this.base = PIXI.Sprite.from(baseTextureName);
+    this.base.anchor.set(0.5);
+    this.addChild(this.base);
+
+    this.effect = new PixiDragonBones(gameCode, resName, armatureName);
+    this.addChild(this.effect);
+  }
+
+  private async centerEffect(): Promise<void> {
+    const anyEffect = this.effect as any;
+    if (anyEffect.buildPromise) {
+      await anyEffect.buildPromise;
+    }
+    const display = anyEffect.armatureDisplay as PIXI.DisplayObject | undefined;
+    if (display) {
+      const bounds = display.getLocalBounds();
+      display.pivot.set(bounds.width / 2, bounds.height / 2);
+      display.position.set(0, 0);
+    }
+    this.effect.position.set(0, 0);
+  }
+
+  public async play(): Promise<void> {
+    await this.effect.play();
+    await this.centerEffect();
+  }
+
+  public async stop(): Promise<void> {
+    await this.effect.stop();
+  }
+
+  public showEffect(): void {
+    this.effect.visible = true;
+  }
+
+  public hideEffect(): void {
+    this.effect.visible = false;
+  }
+}

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -1,6 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
-import { PixiDragonBones } from '../../base/PixiDragonBones';
+import { PixiDragonBonesButton } from '../../base/PixiDragonBonesButton';
 import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
 
 export class AlpszmSlotGame extends BaseSlotGame {
@@ -65,16 +65,17 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.hotSpinText.visible = false;
     this.gameContainer.addChild(this.hotSpinText);
 
-    const alpszm_effect_auto = new PixiDragonBones(
+    const autoBtn = new PixiDragonBonesButton(
       'alpszm',
+      'assets/alpszm/spinButton/Btn_Spin_Get.png',
       'alpszm_a',
       'Anim_Btn_Auto'
     );
-    alpszm_effect_auto.name = 'alpszm_effect_auto';
-    alpszm_effect_auto.x = 560;
-    alpszm_effect_auto.y = 840;
-    alpszm_effect_auto.play();
-    this.gameContainer.addChild(alpszm_effect_auto);
+    autoBtn.name = 'alpszm_effect_auto';
+    autoBtn.x = 560;
+    autoBtn.y = 840;
+    autoBtn.play();
+    this.gameContainer.addChild(autoBtn);
   }
 
   protected onSpinEnd(): void {


### PR DESCRIPTION
## Summary
- add `PixiDragonBonesButton` class for combining a base sprite with a DragonBones animation
- use `PixiDragonBonesButton` in `AlpszmSlotGame`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4e9933d4832d8bc27f34f1c7e9ad