### PR TITLE
Hide upArmature while overlay anim plays

### DIFF
--- a/src/base/SpinButton.ts
+++ b/src/base/SpinButton.ts
@@ -50,7 +50,9 @@ export class SpinButton extends PIXI.Container {
     this.spinIcon.visible = false;
     this.stopIcon.visible = true;
     this.overlayArmature.visible = true;
+    this.upArmature.visible = false;
     await this.overlayArmature.play('Overlay', false);
+    this.upArmature.visible = true;
     if (this.onPressed) this.onPressed();
   }
 


### PR DESCRIPTION
## Summary
- hide `upArmature` during button overlay animation

## Testing
- `yarn test` *(fails: package missing from lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_685e6d23e1b0832dbc7248a19c7a4351