### PR TITLE
Fix repeated entry crash by preserving textures

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -210,7 +210,9 @@ export class Lobby {
     if (this.app) {
       const parent = this.app.view.parentNode;
       if (parent) parent.removeChild(this.app.view);
-      this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+      // Keep textures cached when destroying the lobby so returning to games
+      // that share assets does not fail due to missing base textures
+      this.app.destroy(true, { children: true });
     }
   }
 

--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -701,7 +701,10 @@ export abstract class BaseSlotGame {
       if (parent) {
         parent.removeChild(this.app.view);
       }
-      this.app.destroy(true, { children: true, texture: true, baseTexture: true });
+      // Do not destroy textures so they can be reused when returning to the game
+      // otherwise DragonBones assets will be removed from the global cache
+      // causing errors on subsequent entries
+      this.app.destroy(true, { children: true });
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid destroying textures when exiting slot games
- avoid destroying textures when leaving the lobby

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638ea61218832d88719ee36e473509