### PR TITLE
Add game image preload support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ class SceneManager {
 
   private async startGame(id: string): Promise<void> {
     this.cleanup();
+    await ResourceManager.preloadGameImages(id);
     await ResourceManager.preloadDragonBones(id);
 
     if (id === 'bjxb') {


### PR DESCRIPTION
## Summary
- support loading sprite sheets from each game's `image` folder
- load image atlases before entering a game

## Testing
- `yarn test` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_686391470d04832d9a5274f819da81a9