### PR TITLE
Fix sprite sheet loading

### DIFF
--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -98,7 +98,20 @@ export class ResourceManager {
         const jsonData = res[jsonKey]?.data;
         const texture = res[pngKey]?.texture;
         if (jsonData && texture) {
-          const sheet = new PIXI.Spritesheet(texture.baseTexture ?? texture, jsonData);
+          // Some atlas JSON files in this project use a non-standard
+          // "file" field instead of the expected meta.image property.
+          // Pixi's Spritesheet loader expects json.meta.image to exist,
+          // so provide it if missing to avoid runtime errors.
+          if (!jsonData.meta) {
+            jsonData.meta = { image: jsonData.file };
+          } else if (!jsonData.meta.image && jsonData.file) {
+            jsonData.meta.image = jsonData.file;
+          }
+
+          const sheet = new PIXI.Spritesheet(
+            texture.baseTexture ?? texture,
+            jsonData
+          );
           sheet.parse(() => {
             this.loadedImages[gameCode] = true;
             resolve();


### PR DESCRIPTION
## Summary
- handle atlas JSON that only has a `file` field by creating `meta.image`

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639241dd14832d81d0fbfe8fa8ba3c