### PR TITLE
Add custom symbol block support

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -5,19 +5,35 @@ import { SpinButton } from '../../base/SpinButton';
 import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
 
 export class AlpszmSlotGame extends BaseSlotGame {
+  private readonly customSymbols = [
+    'alpszm_A',
+    'alpszm_E',
+    'alpszm_J',
+    'alpszm_K',
+    'alpszm_N',
+    'alpszm_Q',
+    'alpszm_SA',
+    'alpszm_SB',
+    'alpszm_SC',
+    'alpszm_SD',
+    'alpszm_T',
+    'alpszm_W1',
+    'alpszm_W2'
+  ];
+
   constructor(settings: GameRuleSettings = AlpszmGameSettings) {
-    super(settings, AssetPaths.alpszm);
+    super(settings, AssetPaths.alpszm, this.customSymbols);
   }
   private hunter?: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
   private inHotSpin = false;
   private hotSpinsLeft = 0;
   private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
-  // Symbols are referenced by number strings (e.g. '001')
-  private normalSymbols = Array.from({ length: AssetPaths.alpszm.symbolCount }, (_, i) =>
-    (i + 1).toString().padStart(3, '0')
+  private normalSymbols = this.customSymbols;
+  private hotSymbols = this.customSymbols.slice(
+    0,
+    this.gameSettings.hotSpinSymbolTypeCount
   );
-  private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);
 
   protected getBackgroundPath(): string {
     return AssetPaths.alpszm.bg;

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -1,5 +1,6 @@
 export interface GameAssetConfig {
-  symbolCount: number;
+  symbolCount?: number;
+  customSymbols?: string[];
   // animation type to frame count
   animations?: Record<string, number>;
   bg: string;
@@ -10,7 +11,7 @@ export interface GameAssetConfig {
   /** Optional border image path */
   border?: string;
   lines: { joint: string; body: string };
-  symbol: (index: number) => string;
+  symbol?: (index: number) => string;
   animationFrame: (type: string, index: number) => string;
 }
 
@@ -34,9 +35,9 @@ export interface GameRuleSettings {
   /** Number of rows per reel */
   rows: number;
   /** Width of each block (symbol) in pixels */
-  blockWidth: number;
+  blockWidth?: number;
   /** Height of each block (symbol) in pixels */
-  blockHeight: number;
+  blockHeight?: number;
   /** Horizontal spacing between columns in pixels */
   colSpacing: number;
   /** Vertical spacing between rows in pixels */
@@ -59,7 +60,7 @@ export interface GameRuleSettings {
 
 function createGameConfig(
   name: string,
-  symbolCount: number,
+  symbolCount: number = 0,
   animations?: Record<string, number>,
   hasBorder: boolean = false
 ): GameAssetConfig {
@@ -94,7 +95,7 @@ function createGameConfig(
 export const AssetPaths = {
   bjxb: createGameConfig('bjxb', 10, { hunter: 51 }, true),
   ffp: createGameConfig('ffp', 6, undefined, false),
-  alpszm: createGameConfig('alpszm', 4, undefined, false),
+  alpszm: createGameConfig('alpszm', 0, undefined, false),
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
     backBtn: 'assets/lobby/backBtn.png',
@@ -140,8 +141,8 @@ export const AlpszmGameSettings: GameRuleSettings = {
   ...DefaultGameSettings,
   cols: 5,
   rows: 3,
-  blockWidth: 120,
-  blockHeight: 140,
+  blockWidth: undefined,
+  blockHeight: undefined,
   mapShip: true,
   singleBackground: false,
   colSpacing: 36,


### PR DESCRIPTION
## Summary
- enable custom symbol blocks in `BaseSlotGame`
- allow asset and rule settings to omit symbolCount and block size
- define custom symbols for Alpszm slot game

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686396b93abc832dad8371737e203d6d