### PR TITLE
Fix slot game compile errors

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -4,33 +4,33 @@ import { PixiDragonBonesButton } from '../../base/PixiDragonBonesButton';
 import { SpinButton } from '../../base/SpinButton';
 import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
 
-export class AlpszmSlotGame extends BaseSlotGame {
-  private readonly customSymbols = [
-    'alpszm_A',
-    'alpszm_E',
-    'alpszm_J',
-    'alpszm_K',
-    'alpszm_N',
-    'alpszm_Q',
-    'alpszm_SA',
-    'alpszm_SB',
-    'alpszm_SC',
-    'alpszm_SD',
-    'alpszm_T',
-    'alpszm_W1',
-    'alpszm_W2'
-  ];
+const SYMBOLS = [
+  'alpszm_A',
+  'alpszm_E',
+  'alpszm_J',
+  'alpszm_K',
+  'alpszm_N',
+  'alpszm_Q',
+  'alpszm_SA',
+  'alpszm_SB',
+  'alpszm_SC',
+  'alpszm_SD',
+  'alpszm_T',
+  'alpszm_W1',
+  'alpszm_W2'
+] as const;
 
+export class AlpszmSlotGame extends BaseSlotGame {
   constructor(settings: GameRuleSettings = AlpszmGameSettings) {
-    super(settings, AssetPaths.alpszm, this.customSymbols);
+    super(settings, AssetPaths.alpszm, [...SYMBOLS]);
   }
   private hunter?: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;
   private inHotSpin = false;
   private hotSpinsLeft = 0;
   private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
-  private normalSymbols = this.customSymbols;
-  private hotSymbols = this.customSymbols.slice(
+  private normalSymbols = [...SYMBOLS];
+  private hotSymbols = SYMBOLS.slice(
     0,
     this.gameSettings.hotSpinSymbolTypeCount
   );

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -12,7 +12,7 @@ export class BjxbSlotGame extends BaseSlotGame {
   private hotSpinsLeft = 0;
   private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
   // Symbols are referenced by number strings (e.g. '001')
-  private normalSymbols = Array.from({ length: AssetPaths.bjxb.symbolCount }, (_, i) =>
+  private normalSymbols = Array.from({ length: AssetPaths.bjxb.symbolCount! }, (_, i): string =>
     (i + 1).toString().padStart(3, '0')
   );
   private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -12,7 +12,7 @@ export class FfpSlotGame extends BaseSlotGame {
   private hotSpinsLeft = 0;
   private nextHotSpinScore = this.gameSettings.hotSpinThresholdMultiple;
   // Symbols are referenced by number strings (e.g. '001')
-  private normalSymbols = Array.from({ length: AssetPaths.ffp.symbolCount }, (_, i) =>
+  private normalSymbols = Array.from({ length: AssetPaths.ffp.symbolCount! }, (_, i): string =>
     (i + 1).toString().padStart(3, '0')
   );
   private hotSymbols = this.normalSymbols.slice(0, this.gameSettings.hotSpinSymbolTypeCount);


### PR DESCRIPTION
## Summary
- avoid using `this` before `super` in `AlpszmSlotGame`
- keep custom symbol list as a constant
- tighten `Array.from` usage in Bjxb and Ffp slot games to satisfy TypeScript

## Testing
- `npm test` *(fails: webpack not found)*
- `npx tsc --noEmit` *(fails: cannot find PIXI types)*

------
https://chatgpt.com/codex/tasks/task_e_6863984cb4d0832d873f9d849d745a49