### PR TITLE
Fix ResourceManager image preload

### DIFF
--- a/src/base/ResourceManager.ts
+++ b/src/base/ResourceManager.ts
@@ -92,30 +92,34 @@ export class ResourceManager {
     const jsonUrl = imageContext(jsonKey);
     const pngUrl = imageContext(pngKey);
 
-    return new Promise<void>(resolve => {
-      const loader = new PIXI.Loader();
-      loader.add(`${gameCode}_json`, jsonUrl).add(`${gameCode}_png`, pngUrl);
-      loader.load((l, resources) => {
-        const jsonRes = resources[`${gameCode}_json`];
-        const pngRes = resources[`${gameCode}_png`];
-
-        const jsonData = jsonRes?.data ?? {};
+    return Promise.all([
+      fetch(jsonUrl).then(r => r.json()),
+      new Promise<PIXI.Texture>(res => {
+        const tex = PIXI.Texture.from(pngUrl);
+        if (tex.baseTexture.valid) {
+          res(tex);
+        } else {
+          tex.baseTexture.once('loaded', () => res(tex));
+        }
+      })
+    ])
+      .then(([jsonData, texture]) => {
         if (!jsonData.meta) {
           jsonData.meta = { image: jsonData.file };
         } else if (!jsonData.meta.image && jsonData.file) {
           jsonData.meta.image = jsonData.file;
         }
-
-        const texture = pngRes?.texture ?? PIXI.Texture.EMPTY;
-        const sheet = new PIXI.Spritesheet(texture.baseTexture ?? texture, jsonData);
-        sheet.parse(() => {
-          this.loadedImages[gameCode] = true;
-          resolve();
+        return new Promise<void>(resolve => {
+          const sheet = new PIXI.Spritesheet(texture.baseTexture, jsonData);
+          sheet.parse(() => {
+            this.loadedImages[gameCode] = true;
+            resolve();
+          });
         });
+      })
+      .catch(() => {
+        this.loadedImages[gameCode] = true;
       });
-    }).catch(() => {
-      this.loadedImages[gameCode] = true;
-    });
   }
 
   public static getDragonBonesPaths(


### PR DESCRIPTION
## Summary
- ensure ResourceManager loads spritesheets without triggering extra image requests

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639b8a9074832d966c9d4c8feb0013