### PR TITLE
移除多餘遊戲設定與大廳 Icon

### DIFF
--- a/src/Lobby.ts
+++ b/src/Lobby.ts
@@ -88,8 +88,6 @@ export class Lobby {
     let startY = 0;
 
     const entries = [
-      { id: 'bjxb', name: '雪山尋寶', icon: AssetPaths.lobby.bjxb },
-      { id: 'ffp', name: '水果盤', icon: AssetPaths.lobby.ffp },
       { id: 'alpszm', name: '奧林帕斯', icon: AssetPaths.lobby.alpszm }
     ];
 

--- a/src/games/bjxb/BjxbSlotGame.ts
+++ b/src/games/bjxb/BjxbSlotGame.ts
@@ -1,9 +1,9 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
-import { AssetPaths, BjxbGameSettings, GameRuleSettings } from '../../setting';
+import { AssetPaths, DefaultGameSettings, GameRuleSettings } from '../../setting';
 
 export class BjxbSlotGame extends BaseSlotGame {
-  constructor(settings: GameRuleSettings = BjxbGameSettings) {
+  constructor(settings: GameRuleSettings = DefaultGameSettings) {
     super(settings, AssetPaths.bjxb);
   }
   private hunter?: PIXI.AnimatedSprite;

--- a/src/games/ffp/FfpSlotGame.ts
+++ b/src/games/ffp/FfpSlotGame.ts
@@ -1,9 +1,9 @@
 import * as PIXI from 'pixi.js';
 import { BaseSlotGame } from '../../base/BaseSlotGame';
-import { AssetPaths, GameRuleSettings, FfpGameSettings } from '../../setting';
+import { AssetPaths, GameRuleSettings, DefaultGameSettings } from '../../setting';
 
 export class FfpSlotGame extends BaseSlotGame {
-  constructor(settings: GameRuleSettings = FfpGameSettings) {
+  constructor(settings: GameRuleSettings = DefaultGameSettings) {
     super(settings, AssetPaths.ffp);
   }
   private hunter?: PIXI.AnimatedSprite;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,4 @@
 import * as PIXI from 'pixi.js';
-import { BjxbSlotGame } from './games/bjxb/BjxbSlotGame';
-import { FfpSlotGame } from './games/ffp/FfpSlotGame';
 import { AlpszmSlotGame } from './games/alpszm/AlpszmSlotGame';
 import { Lobby } from './Lobby';
 import { AssetPaths } from './setting';
@@ -21,17 +19,7 @@ class SceneManager {
     await ResourceManager.preloadGameImages(id);
     await ResourceManager.preloadDragonBones(id);
 
-    if (id === 'bjxb') {
-      const game = new BjxbSlotGame();
-      this.current = game;
-      game.start('game');
-      this.addBackButton(game.appInstance);
-    } else if (id === 'ffp') {
-      const game = new FfpSlotGame();
-      this.current = game;
-      game.start('game');
-      this.addBackButton(game.appInstance);
-    } else if (id === 'alpszm') {
+    if (id === 'alpszm') {
       const game = new AlpszmSlotGame();
       this.current = game;
       game.start('game');

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -99,8 +99,6 @@ export const AssetPaths = {
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
     backBtn: 'assets/lobby/backBtn.png',
-    bjxb: 'assets/lobby/lobby_icons/bjxb.png',
-    ffp: 'assets/lobby/lobby_icons/ffp.png',
     alpszm: 'assets/lobby/lobby_icons/alpszm.png'
   }
 } as const;
@@ -122,20 +120,6 @@ export const DefaultGameSettings: GameRuleSettings = {
   singleBackground: false
 };
 
-export const BjxbGameSettings: GameRuleSettings = {
-  ...DefaultGameSettings,
-  singleBackground: true
-};
-
-export const FfpGameSettings: GameRuleSettings = {
-  ...DefaultGameSettings,
-  cols: 5,
-  rows: 5,
-  blockWidth: 128,
-  blockHeight: 90,
-  mapShip: false,
-  singleBackground: true
-};
 
 export const AlpszmGameSettings: GameRuleSettings = {
   ...DefaultGameSettings,


### PR DESCRIPTION
## Summary
- Lobby 只保留 alpszm 遊戲圖示
- 移除 `BjxbGameSettings` 與 `FfpGameSettings`
- bjxb、ffp 遊戲類別改用 `DefaultGameSettings`
- `index.ts` 僅處理 alpszm 遊戲啟動邏輯

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b3316db4832daf98e49c34667960