### PR TITLE
Add auto-spin toggle and sprite visibility control

### DIFF
--- a/src/base/PixiDragonBonesButton.ts
+++ b/src/base/PixiDragonBonesButton.ts
@@ -5,6 +5,7 @@ import { ResourceManager } from './ResourceManager';
 export class PixiDragonBonesButton extends PIXI.Container {
   private base: PIXI.Sprite;
   private effect: PixiDragonBones;
+  private overlaySprites: PIXI.Sprite[] = [];
 
   constructor(
     gameCode: string,
@@ -46,6 +47,7 @@ export class PixiDragonBonesButton extends PIXI.Container {
   }
 
   public async play(): Promise<void> {
+    this.overlaySprites.forEach(s => (s.visible = false));
     this.effect.visible = true;
     await this.centerEffect();
     await this.effect.play();
@@ -54,6 +56,7 @@ export class PixiDragonBonesButton extends PIXI.Container {
   public async stop(): Promise<void> {
     this.effect.visible = false;
     await this.effect.stop();
+    this.overlaySprites.forEach(s => (s.visible = true));
   }
 
   public showEffect(): void {
@@ -86,6 +89,7 @@ export class PixiDragonBonesButton extends PIXI.Container {
       if (tex) {
         const sprite = new PIXI.Sprite(tex);
         sprite.anchor.set(0.5);
+        this.overlaySprites.push(sprite);
         this.addChild(sprite);
       }
     });

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -35,6 +35,8 @@ export class AlpszmSlotGame extends BaseSlotGame {
     0,
     this.gameSettings.hotSpinSymbolTypeCount
   );
+  private autoBtn!: PixiDragonBonesButton;
+  private autoMode = false;
 
   protected getBackgroundPath(): string {
     return AssetPaths.alpszm.bg;
@@ -108,19 +110,22 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.hotSpinText.visible = false;
     this.gameContainer.addChild(this.hotSpinText);
 
-    const autoBtn = new PixiDragonBonesButton(
+    this.autoBtn = new PixiDragonBonesButton(
       'alpszm',
       'alpszm_hang_up_button_normal',
       ['alpszm_hang_up_icon_normal'],
       'alpszm_a',
       'Anim_Btn_Auto'
     );
-    autoBtn.name = 'alpszm_effect_auto';
-    autoBtn.scale.set(AlpszmSlotGameUISetting.autoButton.scale);
-    autoBtn.x = AlpszmSlotGameUISetting.autoButton.x;
-    autoBtn.y = AlpszmSlotGameUISetting.autoButton.y;
-    autoBtn.play();
-    this.gameContainer.addChild(autoBtn);
+    this.autoBtn.name = 'alpszm_effect_auto';
+    this.autoBtn.scale.set(AlpszmSlotGameUISetting.autoButton.scale);
+    this.autoBtn.x = AlpszmSlotGameUISetting.autoButton.x;
+    this.autoBtn.y = AlpszmSlotGameUISetting.autoButton.y;
+    this.autoBtn.interactive = true;
+    this.autoBtn.buttonMode = true;
+    this.autoBtn.on('pointerdown', () => this.toggleAutoMode());
+    this.autoBtn.stop();
+    this.gameContainer.addChild(this.autoBtn);
   }
 
 
@@ -177,6 +182,7 @@ export class AlpszmSlotGame extends BaseSlotGame {
     if (this.mapShip) {
       this.mapShip.reset();
     }
+    this.checkAutoSpin();
   }
 
   private checkHotSpin() {
@@ -195,7 +201,27 @@ export class AlpszmSlotGame extends BaseSlotGame {
     } else {
       if (!this.gameSettings.mapShip && this.score >= this.nextHotSpinScore) {
         this.startHotSpin();
+      } else {
+        this.checkAutoSpin();
       }
+    }
+  }
+
+  private toggleAutoMode() {
+    this.autoMode = !this.autoMode;
+    if (this.autoMode) {
+      this.autoBtn.play();
+      this.checkAutoSpin();
+    } else {
+      this.autoBtn.stop();
+    }
+  }
+
+  private checkAutoSpin() {
+    if (this.autoMode && !this.spinning && !this.inHotSpin) {
+      this.spin(() => {
+        this.onSpinEnd();
+      });
     }
   }
 }


### PR DESCRIPTION
## Summary
- store overlay sprites in `PixiDragonBonesButton`
- toggle sprite visibility when playing/stopping the dragonbones effect
- implement auto spin feature for `AlpszmSlotGame` with new toggle button

## Testing
- `yarn test` *(fails: package missing)*
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d3b98b90832d8a8738128d69c36e