### PR TITLE
Use blur textures during spin

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -25,6 +25,7 @@ const SYMBOLS = [
 export class AlpszmSlotGame extends BaseSlotGame {
   constructor(settings: GameRuleSettings = AlpszmGameSettings) {
     super(settings, AssetPaths.alpszm, [...SYMBOLS]);
+    this.useTextureBlur = true;
   }
   private hunter?: PIXI.AnimatedSprite;
   private hotSpinText!: PIXI.Text;


### PR DESCRIPTION
## Summary
- add texture blur support in `BaseSlotGame`
- switch to blur textures when reels spin
- enable texture blur for `AlpszmSlotGame`

## Testing
- `yarn install` *(fails: Bad response 403)*
- `yarn test` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6864e35c3218832db6e41f6134508445