### PR TITLE
Improve reel braking blur timing

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -689,17 +689,19 @@ export abstract class BaseSlotGame {
             this.unregisterTicker(ticker);
             this.alignReel(reel);
 
+            // restore symbols when braking animation begins
+            if (this.useTextureBlur) {
+              reel.children.forEach((c: any, i: number) => {
+                if (i % this.childPerCell === 0) {
+                  const name = c.name || '';
+                  c.texture = this.getSymbolTexture(name, false);
+                }
+              });
+            } else {
+              reel.filters = [];
+            }
+
             const finish = () => {
-              if (this.useTextureBlur) {
-                reel.children.forEach((c: any, i: number) => {
-                  if (i % this.childPerCell === 0) {
-                    const name = c.name || '';
-                    c.texture = this.getSymbolTexture(name, false);
-                  }
-                });
-              } else {
-                reel.filters = [];
-              }
               if (idx === this.cols - 1) {
                 const wins = this.findLines();
                 if (wins.length > 0) {


### PR DESCRIPTION
## Summary
- restore symbols as soon as the reel braking animation begins

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864e9031f60832dbd2703609f49b184