### PR TITLE
Remove back button and score text

### DIFF
--- a/src/base/BaseSlotGame.ts
+++ b/src/base/BaseSlotGame.ts
@@ -27,7 +27,6 @@ export abstract class BaseSlotGame {
   protected lineContainer!: PIXI.Container;
   protected reels: PIXI.Container[] = [];
   protected score = 0;
-  protected scoreText!: PIXI.Text;
   protected button!: PIXI.Container;
   protected mapShip?: BaseMapShip;
   protected mapShipEndTriggered = false;
@@ -271,18 +270,6 @@ export abstract class BaseSlotGame {
         : defaultY;
     this.gameContainer.addChild(this.reelContainer);
 
-    this.scoreText = new PIXI.Text('Score: 0', {
-      fill: 0xffe066,
-      fontSize: 48,
-      fontWeight: 'bold',
-      stroke: 0x333333,
-      strokeThickness: 6
-    });
-    this.scoreText.anchor.set(0.5, 0);
-    this.scoreText.x = REEL_LAYOUT_WIDTH / 2;
-    this.scoreText.y = BaseSlotGameUISetting.scoreText.y;
-    this.scoreText.visible = false;
-    this.gameContainer.addChild(this.scoreText);
 
     const reelMask = new PIXI.Graphics();
     reelMask.beginFill(0xffffff);
@@ -488,25 +475,6 @@ export abstract class BaseSlotGame {
     };
   }
 
-  protected animateScore() {
-    const start = Date.now();
-    const duration = 600;
-    const ticker = new PIXI.Ticker();
-    this.registerTicker(ticker);
-    ticker.add(() => {
-      const elapsed = Date.now() - start;
-      const progress = Math.min(elapsed / duration, 1);
-      const scale = 1 + 0.5 * Math.sin(progress * Math.PI);
-      this.scoreText.scale.set(scale);
-      if (progress === 1) {
-        this.scoreText.scale.set(1);
-        ticker.stop();
-        ticker.destroy();
-        this.unregisterTicker(ticker);
-      }
-    });
-    ticker.start();
-  }
 
   protected showWin(lines: any[], onDone: () => void) {
     if (this.mapShip) {
@@ -554,8 +522,6 @@ export abstract class BaseSlotGame {
     const gained = uniqueCells.size * this.gameSettings.scorePerBlock;
     if (gained > 0) {
       this.score += gained;
-      this.scoreText.text = `Score: ${this.score}`;
-      this.animateScore();
     }
 
     const pulseTicker = new PIXI.Ticker();

--- a/src/base/BaseSlotGame_uiSetting.ts
+++ b/src/base/BaseSlotGame_uiSetting.ts
@@ -1,7 +1,4 @@
 export const BaseSlotGameUISetting = {
-  scoreText: {
-    y: 20,
-  },
   spinButton: {
     offsetY: 20,
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import * as PIXI from 'pixi.js';
 import { AlpszmSlotGame } from './games/alpszm/AlpszmSlotGame';
 import { Lobby } from './Lobby';
-import { AssetPaths } from './setting';
 import { ResourceManager } from './base/ResourceManager';
 
 class SceneManager {
@@ -23,18 +22,7 @@ class SceneManager {
       const game = new AlpszmSlotGame();
       this.current = game;
       game.start('game');
-      this.addBackButton(game.appInstance);
     }
-  }
-
-  private addBackButton(app: PIXI.Application): void {
-    const btn = PIXI.Sprite.from(AssetPaths.lobby.backBtn);
-    btn.interactive = true;
-    btn.buttonMode = true;
-    btn.x = 20;
-    btn.y = 20;
-    btn.on('pointertap', () => this.showLobby());
-    app.stage.addChild(btn);
   }
 
   private cleanup(): void {

--- a/src/setting.ts
+++ b/src/setting.ts
@@ -94,7 +94,6 @@ export const AssetPaths = {
   alpszm: createGameConfig('alpszm', 0, undefined, false),
   lobby: {
     bg: 'assets/lobby/lobby_bg.png',
-    backBtn: 'assets/lobby/backBtn.png',
     alpszm: 'assets/lobby/lobby_icons/alpszm.png'
   }
 } as const;


### PR DESCRIPTION
## Summary
- remove back button creation from scene manager
- drop lobby back button asset path
- remove BaseSlotGame score display logic

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865f05c6d38832db28c38be77bb3706