### PR TITLE
Fix slot line manager usage

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -6,7 +6,7 @@ import { AlpszmSlotGameUISetting } from './AlpszmSlotGame_uiSetting';
 import { AssetPaths, GameRuleSettings, AlpszmGameSettings } from '../../setting';
 import { ResourceManager } from '../../base/ResourceManager';
 import { GameDescription, GameDescriptionConfig } from '../../base/GameDescription';
-import { PixiSlotLineMgr } from '../../base/PixiSlotLineMgr';
+import { SlotLineMgr } from '../../base/PixiSlotLineMgr';
 
 const SYMBOLS = [
   'alpszm_A',
@@ -564,11 +564,11 @@ export class AlpszmSlotGame extends BaseSlotGame {
       this.score += gained;
     }
 
-    PixiSlotLineMgr.Set_Winning(plate, winning_list as any, [], winning_line_index_list);
-    PixiSlotLineMgr.Set_TotalLine();
+    SlotLineMgr.Set_Winning(plate, winning_list as any, [], winning_line_index_list);
+    SlotLineMgr.Set_TotalLine();
 
     const timeoutId = window.setTimeout(() => {
-      PixiSlotLineMgr.Clear_AniGroup_All();
+      SlotLineMgr.Clear_AniGroup_All();
       this.onSpinEnd();
       onDone();
     }, this.WIN_TIME);


### PR DESCRIPTION
## Summary
- use the singleton `SlotLineMgr` instead of the class `PixiSlotLineMgr`

## Testing
- `npm test` *(fails: webpack not found)*
- `npm run build` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b93124f68832d99b5bae85ab4ff81