### PR TITLE
Fix missing slot line animations

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -175,6 +175,9 @@ export class AlpszmSlotGame extends BaseSlotGame {
       arrSymCount
     );
     SlotLineMgr.Set_Symbol(arrPosY, this.symbolEffectLayer);
+    // initialize line and way animations for SlotLineMgr
+    SlotLineMgr.Set_Line(PAYLINES.length, 'Anim_Line', this.lineEffectLayer);
+    SlotLineMgr.Set_Way(arrPosY, this.wayEffectLayer);
 
     const GAME_WIDTH = this.cols * this.cellWidth;
     const HUNTER_SCALE = AlpszmSlotGameUISetting.hunter.scale;


### PR DESCRIPTION
## Summary
- ensure line and way DragonBones animations are set up

## Testing
- `yarn test` *(fails: package not present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686b99ee2708832da1cee72cfcd9a3f8