### PR TITLE
Fix symbol visibility during line animations

### DIFF
--- a/src/base/PixiSlotLineMgr.ts
+++ b/src/base/PixiSlotLineMgr.ts
@@ -312,8 +312,8 @@ class PixiSlotLineMgr extends SlotLineClass {
     }
 
     if (!this.plate_symbol_aniGroup[row][col].visible) {
-      this.slot_controller.getSymbol(row, col).visible = false;
-
+      // Keep original symbol visible so it doesn't disappear while the
+      // DragonBones animation plays on top of it.
       const loop_flag = !loop;
       this.plate_symbol_aniGroup[row][col].visible = true;
       this.plate_symbol_aniGroup[row][col].play(symbolName, loop_flag);


### PR DESCRIPTION
## Summary
- keep base symbol visible when showing DragonBones symbol animation

## Testing
- `npm test` *(fails: `webpack: not found`)*
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686b9a97655c832da6f251db9d8dfe5e