### PR TITLE
Add testLine flag and effect layer settings

### DIFF
--- a/src/base/PixiSlotLineMgr.ts
+++ b/src/base/PixiSlotLineMgr.ts
@@ -14,6 +14,9 @@ class PixiSlotLineMgr extends SlotLineClass {
   /** Current game code used for loading DragonBones assets */
   private gameCode = '';
 
+  /** Flag for keeping line animations visible for debugging */
+  public testLine = false;
+
   public setGameCode(code: string): void {
     this.gameCode = code;
   }
@@ -245,6 +248,7 @@ class PixiSlotLineMgr extends SlotLineClass {
   }
 
   public Clear_AniGroup_All(): void {
+    if (this.testLine) return;
     this.Clear_AniGroup_Symbol();
 
     if (this.type === Line_Type.Line) {

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -151,11 +151,12 @@ export class AlpszmSlotGame extends BaseSlotGame {
     this.symbolEffectLayer = new PIXI.Container();
     this.lineEffectLayer = new PIXI.Container();
     this.wayEffectLayer = new PIXI.Container();
+    const effectSetting = AlpszmSlotGameUISetting.effectLayer;
     [this.symbolEffectLayer, this.lineEffectLayer, this.wayEffectLayer].forEach(
       layer => {
-        layer.x = this.reelContainer.x;
-        layer.y = this.reelContainer.y;
-        layer.scale.set(this.REEL_SCALE);
+        layer.x = this.reelContainer.x + effectSetting.xOffset;
+        layer.y = this.reelContainer.y + effectSetting.yOffset;
+        layer.scale.set(this.REEL_SCALE * effectSetting.scale);
         this.gameContainer.addChild(layer);
       }
     );

--- a/src/games/alpszm/AlpszmSlotGame_uiSetting.ts
+++ b/src/games/alpszm/AlpszmSlotGame_uiSetting.ts
@@ -48,4 +48,13 @@ export const AlpszmSlotGameUISetting = {
     offsetX: 82,
     offsetY: 40,
   },
+  /**
+   * Offset and scale for the containers used to play line animations.
+   * These values are relative to the reel container position and scale.
+   */
+  effectLayer: {
+    xOffset: 0,
+    yOffset: 0,
+    scale: 1,
+  },
 };


### PR DESCRIPTION
## Summary
- add configuration for line animation effect container position and scale
- support debugging via `testLine` flag in PixiSlotLineMgr

## Testing
- `npm test` *(fails: webpack not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cc4d9a9cc832d9b6aa59d0f32574f