### PR TITLE
feat: display score overlay in alpszm slot

### DIFF
--- a/src/base/ShowScore.ts
+++ b/src/base/ShowScore.ts
@@ -1,0 +1,125 @@
+import * as PIXI from 'pixi.js';
+import { PixiDragonBones } from './PixiDragonBones';
+
+/**
+ * ShowScore - displays a score overlay using a DragonBones background and
+ * bitmap number graphics.
+ */
+export class ShowScore extends PIXI.Container {
+  private static fontCache: Record<string, Record<string, PIXI.Texture>> = {};
+
+  constructor(private app: PIXI.Application, private gameCode: string) {
+    super();
+  }
+
+  /** Show the score using the provided DragonBones animation. */
+  public async show(value: number, anim: PixiDragonBones): Promise<void> {
+    const textures = await this.loadFontTextures();
+
+    const bg = new PIXI.Graphics();
+    bg.beginFill(0x000000, 0.7);
+    bg.drawRect(0, 0, this.app.screen.width, this.app.screen.height);
+    bg.endFill();
+    bg.interactive = true; // block interactions
+    this.addChild(bg);
+
+    anim.x = this.app.screen.width / 2;
+    anim.y = this.app.screen.height / 2;
+    this.addChild(anim);
+
+    const numContainer = new PIXI.Container();
+    const digits = value.toString().split('');
+    let totalWidth = 0;
+    const sprites: PIXI.Sprite[] = [];
+    digits.forEach(d => {
+      const tex = textures[d];
+      if (!tex) return;
+      const s = new PIXI.Sprite(tex);
+      sprites.push(s);
+      totalWidth += s.width;
+    });
+    let x = -totalWidth / 2;
+    sprites.forEach(s => {
+      s.x = x;
+      x += s.width;
+      numContainer.addChild(s);
+    });
+    numContainer.x = this.app.screen.width / 2;
+    numContainer.y = this.app.screen.height / 2;
+    this.addChild(numContainer);
+
+    this.app.stage.addChild(this);
+    await PixiDragonBones.play(anim, 'Anim_Score', 1);
+    this.app.stage.removeChild(this);
+    anim.release();
+    this.destroy({ children: true });
+  }
+
+  private async loadFontTextures(): Promise<Record<string, PIXI.Texture>> {
+    if (ShowScore.fontCache[this.gameCode]) {
+      return ShowScore.fontCache[this.gameCode];
+    }
+
+    const base = `assets/${this.gameCode}/font/${this.gameCode}_totalscore_font`;
+    const [jsonData, texture] = await Promise.all([
+      fetch(`${base}.fnt`).then(r => r.json()),
+      new Promise<PIXI.Texture>(resolve => {
+        const tex = PIXI.Texture.from(`${base}.png`);
+        if (tex.baseTexture.valid) {
+          resolve(tex);
+        } else {
+          tex.baseTexture.once('loaded', () => resolve(tex));
+        }
+      })
+    ]);
+
+    const sheetData = ShowScore.convertEgretToPIXI(jsonData);
+    const sheet = new PIXI.Spritesheet(texture.baseTexture, sheetData);
+    await new Promise(resolve => sheet.parse(() => resolve(undefined)));
+    ShowScore.fontCache[this.gameCode] = sheet.textures;
+    return sheet.textures;
+  }
+
+  // Convert Egret texture data to PIXI format.
+  private static convertEgretToPIXI(egretData: any): any {
+    const pixiData = {
+      frames: {} as { [key: string]: any },
+      meta: {
+        image: egretData.file,
+        format: 'RGBA8888',
+        size: { w: 0, h: 0 }
+      }
+    };
+
+    for (const [frameName, frameData] of Object.entries(egretData.frames)) {
+      const egretFrame = frameData as any;
+      pixiData.frames[frameName] = {
+        frame: {
+          x: egretFrame.x,
+          y: egretFrame.y,
+          w: egretFrame.w,
+          h: egretFrame.h
+        },
+        rotated: false,
+        trimmed:
+          egretFrame.offX !== 0 ||
+          egretFrame.offY !== 0 ||
+          egretFrame.w !== egretFrame.sourceW ||
+          egretFrame.h !== egretFrame.sourceH,
+        spriteSourceSize: {
+          x: egretFrame.offX || 0,
+          y: egretFrame.offY || 0,
+          w: egretFrame.w,
+          h: egretFrame.h
+        },
+        sourceSize: {
+          w: egretFrame.sourceW || egretFrame.w,
+          h: egretFrame.sourceH || egretFrame.h
+        }
+      };
+    }
+
+    return pixiData;
+  }
+}
+

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -8,6 +8,8 @@ import { ResourceManager } from '../../base/ResourceManager';
 import { GameDescription, GameDescriptionConfig } from '../../base/GameDescription';
 import { SlotLineMgr } from '../../base/PixiSlotLineMgr';
 import { Line_Type } from '../../base/PixiSlotLineClass';
+import { ShowScore } from '../../base/ShowScore';
+import { PixiDragonBones } from '../../base/PixiDragonBones';
 
 const SYMBOLS = [
   'alpszm_A',
@@ -602,6 +604,9 @@ export class AlpszmSlotGame extends BaseSlotGame {
     const gained = uniqueCells.size * this.gameSettings.scorePerBlock;
     if (gained > 0) {
       this.score += gained;
+      const anim = new PixiDragonBones('alpszm', 'alpszm_b', 'Anim_Score');
+      const show = new ShowScore(this.app, 'alpszm');
+      show.show(gained, anim);
     }
 
     SlotLineMgr.Set_Winning(plate, winning_list, [], winning_line_index_list);


### PR DESCRIPTION
## Summary
- add reusable ShowScore component to render scores with DragonBones base and bitmap digits
- trigger ShowScore in AlpszmSlotGame when wins occur

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891b6c74d44832daaaee786de985d53