### PR TITLE
Fix ShowScore animation selection

### DIFF
--- a/src/base/ShowScore.ts
+++ b/src/base/ShowScore.ts
@@ -55,7 +55,7 @@ export class ShowScore extends PIXI.Container {
     this.addChild(numContainer);
 
     this.app.stage.addChild(this);
-    await anim.play('Anim_Score', false);
+    await anim.play('Few', false);
     await new Promise(resolve => setTimeout(resolve, 2000));
     this.app.stage.removeChild(this);
     anim.release();

--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -604,7 +604,7 @@ export class AlpszmSlotGame extends BaseSlotGame {
     const gained = uniqueCells.size * this.gameSettings.scorePerBlock;
     if (gained > 0) {
       this.score += gained;
-      const anim = new PixiDragonBones('alpszm', 'alpszm_b', 'Anim_Score');
+      const anim = new PixiDragonBones('alpszm', 'alpszm_b', 'Anim_W_Few');
       const show = new ShowScore(this.app, 'alpszm');
       show.show(gained, anim);
     }


### PR DESCRIPTION
## Summary
- Use Anim_W_Few armature for score display
- Play Few animation when showing score

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c1cd1cd4832db2504c07a153c311