### PR TITLE
fix: handle dragonbones armature build timing

### DIFF
--- a/src/base/PixiDragonBones.ts
+++ b/src/base/PixiDragonBones.ts
@@ -66,11 +66,25 @@ export class PixiDragonBones extends PIXI.Container {
     times: number = 1,
     callback?: () => void
   ): Promise<void> {
-    return new Promise((resolve) => {
-      const display = armature.armatureDisplay;
+    return new Promise(async (resolve) => {
+      let display: any;
+
+      if (armature instanceof PixiDragonBones) {
+        await armature.buildPromise;
+        display = armature.armatureDisplay;
+      } else if (armature && armature.armatureDisplay) {
+        display = armature.armatureDisplay;
+      } else {
+        display = armature;
+      }
+
+      if (!display) {
+        if (callback) callback();
+        resolve();
+        return;
+      }
 
       if (times === 0) {
-        // 無限播放：立即執行 callback 和 resolve
         display.animation.play(animName, 0);
         if (callback) callback();
         resolve();


### PR DESCRIPTION
## Summary
- ensure PixiDragonBones.play waits for armature build
- guard against missing displays when starting animations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892fd8ec210832d9e9e65f716434ec9