### PR TITLE
fix: delay removal of hot spin intro animation

### DIFF
--- a/src/games/alpszm/AlpszmSlotGame.ts
+++ b/src/games/alpszm/AlpszmSlotGame.ts
@@ -411,9 +411,13 @@ export class AlpszmSlotGame extends BaseSlotGame {
     intro.y = this.app.screen.height / 2;
     this.app.stage.addChild(intro);
     await PixiDragonBones.play(intro, 'Free', 1);
-    await new Promise(resolve => setTimeout(resolve, 500));
-    intro.release();
-    this.app.stage.removeChild(intro);
+    await new Promise<void>((resolve) => {
+      setTimeout(() => {
+        intro.release();
+        this.app.stage.removeChild(intro);
+        resolve();
+      }, 500);
+    });
 
     if (this.hunter) {
       this.hunter.play();


### PR DESCRIPTION
## Summary
- wait 500ms before removing Anim_W_Free dragonbones intro animation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689303302db8832db9810cdc235dae04